### PR TITLE
Forces renv restore to cache #25

### DIFF
--- a/R/ModuleInstantiation.R
+++ b/R/ModuleInstantiation.R
@@ -159,7 +159,7 @@ instantiateModule <- function(module, version, remoteRepo, remoteUsername, modul
   }
 
   script <- "
-      renv::restore(prompt = FALSE)
+      renv::restore(prompt = FALSE, library = renv::paths$cache())
       if (!require('ParallelLogger', quietly = TRUE)) {
         install.packages('ParallelLogger')
       }


### PR DESCRIPTION
Updates the call to `renv::restore()` to specify the [library](https://rstudio.github.io/renv/reference/restore.html#library) location and set it to the location configured for the renv cache to prevent corruption of the user's R library.