### PR TITLE
Enforce module structure

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,17 +18,18 @@ Depends:
 	CohortGenerator (>= 0.7.0),
 	DatabaseConnector (>= 5.1.0)
 Imports:
-	targets,
-	renv (>= 0.15.5),
-	ParallelLogger (>= 3.1.0),
-	dplyr,
-	checkmate,
-	keyring,
-	rlang,
-	utils,
-	R.utils,
-	digest,
-	methods
+  targets,
+  renv (>= 0.15.5),
+  ParallelLogger (>= 3.1.0),
+  dplyr,
+  checkmate,
+  keyring,
+  rlang,
+  utils,
+  R.utils,
+  digest,
+  methods,
+  tibble
 Suggests:
 	testthat,
 	fs,

--- a/R/ModuleInstantiation.R
+++ b/R/ModuleInstantiation.R
@@ -78,7 +78,7 @@ ensureAllModulesInstantiated <- function(analysisSpecifications) {
     moduleTablePrefixesInConflict <- moduleTablePrefixes %>%
       group_by(.data$tablePrefix) %>%
       summarise(totalCount = n()) %>%
-      filter(totalCount > 1)
+      filter(.data$totalCount > 1)
 
     message <- paste(c(
       "Detected colliding result table prefixes:",
@@ -239,9 +239,9 @@ getModuleRenvDependencies <- function(moduleFolder) {
 
   missingFiles <- tibble::enframe(renvRequiredFiles) %>%
     mutate(fileExists = file.exists(file.path(moduleFolder, .data$value))) %>%
-    rename(fileName = value) %>%
-    select(fileName, fileExists) %>%
-    filter(fileExists == FALSE)
+    rename(fileName = .data$value) %>%
+    select(.data$fileName, .data$fileExists) %>%
+    filter(.data$fileExists == FALSE)
 
   invisible(missingFiles)
 }

--- a/man/createEmptyAnalysisSpecificiations.Rd
+++ b/man/createEmptyAnalysisSpecificiations.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/Settings.R
 \name{createEmptyAnalysisSpecificiations}
 \alias{createEmptyAnalysisSpecificiations}
-\title{Create an emtpy analysis specifications object.}
+\title{Create an empty analysis specifications object.}
 \usage{
 createEmptyAnalysisSpecificiations()
 }
@@ -10,5 +10,5 @@ createEmptyAnalysisSpecificiations()
 An object of type \code{AnalysisSpecifications}.
 }
 \description{
-Create an emtpy analysis specifications object.
+Create an empty analysis specifications object.
 }


### PR DESCRIPTION
Adds additional checks to ensure that modules have all of the necessary renv dependencies #33 and also checks to ensure there are no conflicts in table prefixes between modules.