### PR TITLE
Allow passing of renv configuration options when running Strategus

### DIFF
--- a/R/ModuleEnv.R
+++ b/R/ModuleEnv.R
@@ -85,12 +85,13 @@ withModuleRenv <- function(code,
   if (useLocalStrategusLibrary) {
     script <- c(.getLocalLibraryScipt("Strategus"), script)
     # Adding Strategus dependencies to the script
-    c(.getLocalLibraryScipt("R6"), script)
-    c(.getLocalLibraryScipt("CohortGenerator"), script)
-    c(.getLocalLibraryScipt("DatabaseConnector"), script)
-    c(.getLocalLibraryScipt("keyring"), script)
-    c(.getLocalLibraryScipt("openssl"), script)
-    c(.getLocalLibraryScipt("dplyr"), script)
+    script <- c(.getLocalLibraryScipt("ParallelLogger"), script)
+    script <- c(.getLocalLibraryScipt("CohortGenerator"), script)
+    script <- c(.getLocalLibraryScipt("DatabaseConnector"), script)
+    script <- c(.getLocalLibraryScipt("keyring"), script)
+    script <- c(.getLocalLibraryScipt("openssl"), script)
+    script <- c(.getLocalLibraryScipt("dplyr"), script)
+    script <- c(.getLocalLibraryScipt("R6"), script)
   }
 
   # Write file and execute script inside an renv

--- a/R/ModuleEnv.R
+++ b/R/ModuleEnv.R
@@ -67,6 +67,20 @@ withModuleRenv <- function(code,
     script <- gsub(name, rep, script)
   }
 
+  # Attach renv options() from the calling environment to the renv::run context
+  # renv options are prefixed with "renv." as described in
+  # https://rstudio.github.io/renv/reference/config.html
+  envOptions <- options()
+  renvOptions <- envOptions[grepl("renv\\.", names(envOptions))]
+  if (length(renvOptions) > 0) {
+    for (i in 1:length(renvOptions)) {
+      script <- c(.copyOptionForScript(
+        optionName = names(renvOptions)[[i]],
+        optionValue = renvOptions[[i]]
+      ), script)
+    }
+  }
+
   # Enforce attachment of Strategus from calling process - note one inside the renv
   if (useLocalStrategusLibrary) {
     script <- c(.getLocalLibraryScipt("Strategus"), script)
@@ -95,4 +109,16 @@ withModuleRenv <- function(code,
 .getLocalLibraryScipt <- function(x) {
   libPath <- file.path(find.package(x), "../")
   sprintf("library(%s, lib.loc = '%s')", x, libPath)
+}
+
+.copyOptionForScript <- function(optionName, optionValue) {
+  if (is.logical(optionValue) || is.numeric(optionValue)) {
+    sprintf("options(%s = %s)", optionName, optionValue)
+  } else if (is.character(optionValue) && length(optionValue) == 1) {
+    sprintf("options(%s = '%s')", optionName, optionValue)
+  } else if (is.character(optionValue) && length(optionValue) > 1) {
+    sprintf("options(%s = c('%s'))", optionName, paste(optionValue, collapse = "','"))
+  } else {
+    paste0("# option = ", optionName, " - could not be passed to this file, likely because it is a function.")
+  }
 }

--- a/R/ModuleInstantiation.R
+++ b/R/ModuleInstantiation.R
@@ -191,25 +191,18 @@ instantiateModule <- function(module, version, remoteRepo, remoteUsername, modul
     stop(message)
   }
 
-  script <- paste(
-    c(
-      "renv::install(c('ParallelLogger', 'keyring'), prompt = FALSE)",
-      sprintf("ParallelLogger::addDefaultFileLogger(file.path('%s', 'moduleInitLog.txt'))", moduleFolder),
-      sprintf("ParallelLogger::addDefaultErrorReportLogger(fileName = file.path('%s', 'moduleInitErrorReport.txt'))", moduleFolder),
-      "renv::restore(prompt = FALSE)"
-     ),
-    collapse = "\n"
-  )
-  tempScriptFile <- tempfile(fileext = ".R")
-  fileConn <- file(tempScriptFile)
-  writeLines(script, fileConn)
-  close(fileConn)
-
-  renv::run(
-    script = tempScriptFile,
-    job = FALSE,
-    name = "Buidling renv library",
-    project = moduleFolder
+  withModuleRenv(
+    code = {
+      ParallelLogger::addDefaultFileLogger(
+        fileName = file.path(moduleFolder, 'moduleInitLog.txt')
+      )
+      ParallelLogger::addDefaultErrorReportLogger(
+        fileName = file.path(moduleFolder, 'moduleInitErrorReport.txt')
+      )
+      renv::restore(prompt = FALSE)
+    },
+    moduleFolder = moduleFolder,
+    injectVars = list(moduleFolder = moduleFolder)
   )
   success <- TRUE
 }


### PR DESCRIPTION
Fixes #86 by copying `options()` that start with `renv.*` when issuing the `renv::run` command. Also fixes a bug when constructing the local library options.

