### PR TITLE
Add PLP RDMS to results

### DIFF
--- a/.github/workflows/R_CMD_check_Hades.yaml
+++ b/.github/workflows/R_CMD_check_Hades.yaml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Upload source package
         if: success() && runner.os == 'Windows' && github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: package_tarball
           path: check/*.tar.gz
@@ -156,7 +156,7 @@ jobs:
       #
       # - name: Download package tarball
       #   if: ${{ env.new_version != '' }}
-      #   uses: actions/download-artifact@v2
+      #   uses: actions/download-artifact@v4
       #   with:
       #     name: package_tarball
       #

--- a/R/Module-PatientLevelPrediction.R
+++ b/R/Module-PatientLevelPrediction.R
@@ -34,7 +34,7 @@ PatientLevelPredictionModule <- R6::R6Class(
         cohortDatabaseSchema = jobContext$moduleExecutionSettings$workDatabaseSchema,
         cdmDatabaseName = jobContext$moduleExecutionSettings$connectionDetailsReference,
         cdmDatabaseId = jobContext$moduleExecutionSettings$cdmDatabaseMetaData$databaseId,
-        # tempEmulationSchema =  , is there s temp schema specified anywhere?
+        tempEmulationSchema = jobContext$moduleExecutionSettings$tempEmulationSchema,
         cohortTable = jobContext$moduleExecutionSettings$cohortTableNames$cohortTable,
         outcomeDatabaseSchema = jobContext$moduleExecutionSettings$workDatabaseSchema,
         outcomeTable = jobContext$moduleExecutionSettings$cohortTableNames$cohortTable
@@ -71,6 +71,13 @@ PatientLevelPredictionModule <- R6::R6Class(
         ),
         csvFolder = file.path(resultsFolder),
         fileAppend = NULL
+      )
+
+      resultsDataModel <- private$.getResultsDataModelSpecification()
+      CohortGenerator::writeCsv(
+        x = resultsDataModel,
+        file = file.path(resultsFolder, "resultsDataModelSpecification.csv"),
+        warnOnFileNameCaseMismatch = F
       )
 
       private$.message(paste("Results available at:", resultsFolder))
@@ -166,6 +173,19 @@ PatientLevelPredictionModule <- R6::R6Class(
       }
 
       return(modelDesignList)
+    },
+    .getResultsDataModelSpecification = function() {
+      rdms <- CohortGenerator::readCsv(
+        file = private$.getResultsDataModelSpecificationFileLocation()
+      )
+      rdms$tableName <-paste0(self$tablePrefix, rdms$tableName)
+      return(rdms)
+    },
+    .getResultsDataModelSpecificationFileLocation = function() {
+      return(system.file(
+        file.path("settings", "resultsDataModelSpecification.csv"),
+        package = "PatientLevelPrediction"
+      ))
     }
   )
 )


### PR DESCRIPTION
Adds the PatientLevelPrediction results data model specification to the results exported when running the module.

Also includes updates for GHA to use the latest versions to avoid test failures.

