### PR TITLE
Use CdmExecutionSettings to set the cohort schema and table for `createCohortBasedCovariateSettings`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: Strategus
 Type: Package
 Title: Coordinate and Execute OHDSI HADES Modules
-Version: 1.0.0
-Date: 2024-10-08
+Version: 1.1.0
+Date: 2024-11-12
 Authors@R: c(
 	person("Anthony", "Sena", email = "sena@ohdsi.org", role = c("aut", "cre")),
 	person("Martijn", "Schuemie", email = "schuemie@ohdsi.org", role = c("aut")),

--- a/R/StrategusModule.R
+++ b/R/StrategusModule.R
@@ -317,7 +317,7 @@ StrategusModule <- R6::R6Class(
   checkmate::assertClass(executionSettings, "ExecutionSettings", add = errorMessages)
   checkmate::reportAssertions(collection = errorMessages)
 
-  .replaceAttributes <- function(s) {
+  .replaceProperties <- function(s) {
     if (inherits(s, "covariateSettings") && "fun" %in% names(attributes(s))) {
       if (attr(s, "fun") == "getDbCohortBasedCovariatesData") {
         # Set the covariateCohortDatabaseSchema & covariateCohortTable values
@@ -329,10 +329,10 @@ StrategusModule <- R6::R6Class(
   }
   if (is.null(names(covariateSettings))) {
     # List of lists
-    modifiedCovariateSettings <- lapply(covariateSettings, .replaceAttributes)
+    modifiedCovariateSettings <- lapply(covariateSettings, .replaceProperties)
   } else {
     # Plain list
-    modifiedCovariateSettings <- .replaceAttributes(covariateSettings)
+    modifiedCovariateSettings <- .replaceProperties(covariateSettings)
   }
   return(modifiedCovariateSettings)
 }
@@ -351,7 +351,12 @@ StrategusModule <- R6::R6Class(
       return(.replaceCovariateSettingsCohortTableNames(x, executionSettings))
     } else if (is.list(x)) {
       # If the element is a list, recurse on each element
-      return(lapply(x, replaceHelper))
+      # Keep the original attributes by saving them before modification
+      attrs <- attributes(x)
+      newList <- lapply(x, replaceHelper)
+      # Restore attributes to the new list
+      attributes(newList) <- attrs
+      return(newList)
     } else {
       # If the element is not a list or "covariateSettings", return it as is
       return(x)

--- a/R/StrategusModule.R
+++ b/R/StrategusModule.R
@@ -294,3 +294,33 @@ StrategusModule <- R6::R6Class(
     }
   )
 )
+
+# Utility function to set the cohort table & schema on
+# createCohortBasedCovariateSettings with information from
+# the execution settings (Issue #181)
+.replaceCovariateSettingsCohortTableNames <- function(covariateSettings, executionSettings) {
+  errorMessages <- checkmate::makeAssertCollection()
+  checkmate::assertList(covariateSettings, min.len = 1, add = errorMessages)
+  checkmate::assertClass(executionSettings, "ExecutionSettings", add = errorMessages)
+  checkmate::reportAssertions(collection = errorMessages)
+
+  .replaceAttributes <- function(s) {
+    if (inherits(s, "covariateSettings") && "fun" %in% names(attributes(s))) {
+      if (attr(s, "fun") == "getDbCohortBasedCovariatesData") {
+        # Set the covariateCohortDatabaseSchema & covariateCohortTable values
+        s$covariateCohortDatabaseSchema = executionSettings$workDatabaseSchema
+        s$covariateCohortTable = executionSettings$cohortTableNames$cohortTable
+      }
+    }
+    return(s)
+  }
+  if (is.null(names(covariateSettings))) {
+    # List of lists
+    modifiedCovariateSettings <- lapply(covariateSettings, .replaceAttributes)
+  } else {
+    # Plain list
+    modifiedCovariateSettings <- .replaceAttributes(covariateSettings)
+  }
+  return(modifiedCovariateSettings)
+}
+

--- a/R/StrategusModule.R
+++ b/R/StrategusModule.R
@@ -166,7 +166,6 @@ StrategusModule <- R6::R6Class(
         executionSettings = executionSettings
       )
 
-
       # Assemble the job context from the analysis specification
       # for the given module.
       private$jobContext$sharedResources <- analysisSpecifications$sharedResources
@@ -345,7 +344,6 @@ StrategusModule <- R6::R6Class(
   checkmate::reportAssertions(collection = errorMessages)
 
   # A helper function to perform the replacement
-  for (i in seq_along(length(moduleSettings)))
   replaceHelper <- function(x) {
     if (is.list(x) && inherits(x, "covariateSettings")) {
       # If the element is a list and of type covariate settings

--- a/R/StrategusModule.R
+++ b/R/StrategusModule.R
@@ -160,11 +160,14 @@ StrategusModule <- R6::R6Class(
       private$jobContext$settings <- moduleSpecification$settings
 
       # Make sure that the covariate settings for the analysis are updated
-      # to reflect the location of the cohort tables
-      private$jobContext$settings <- .replaceCovariateSettings(
-        moduleSettings = private$jobContext$settings,
-        executionSettings = executionSettings
-      )
+      # to reflect the location of the cohort tables if we are executing
+      # on a CDM.
+      if (inherits(executionSettings, "CdmExecutionSettings")) {
+        private$jobContext$settings <- .replaceCovariateSettings(
+          moduleSettings = private$jobContext$settings,
+          executionSettings = executionSettings
+        )
+      }
 
       # Assemble the job context from the analysis specification
       # for the given module.

--- a/R/StrategusModule.R
+++ b/R/StrategusModule.R
@@ -317,7 +317,7 @@ StrategusModule <- R6::R6Class(
 .replaceCovariateSettingsCohortTableNames <- function(covariateSettings, executionSettings) {
   errorMessages <- checkmate::makeAssertCollection()
   checkmate::assertList(covariateSettings, min.len = 1, add = errorMessages)
-  checkmate::assertClass(executionSettings, "ExecutionSettings", add = errorMessages)
+  checkmate::assertClass(executionSettings, "CdmExecutionSettings", add = errorMessages)
   checkmate::reportAssertions(collection = errorMessages)
 
   .replaceProperties <- function(s) {
@@ -343,7 +343,7 @@ StrategusModule <- R6::R6Class(
 .replaceCovariateSettings <- function(moduleSettings, executionSettings) {
   errorMessages <- checkmate::makeAssertCollection()
   checkmate::assertList(moduleSettings, min.len = 1, add = errorMessages)
-  checkmate::assertClass(executionSettings, "ExecutionSettings", add = errorMessages)
+  checkmate::assertClass(executionSettings, "CdmExecutionSettings", add = errorMessages)
   checkmate::reportAssertions(collection = errorMessages)
 
   # A helper function to perform the replacement

--- a/tests/testthat/test-Settings.R
+++ b/tests/testthat/test-Settings.R
@@ -414,6 +414,13 @@ test_that("Test internal function for modifying covariate settings", {
   # 1) covariate settings that do not contain cohort table settings
   # 2) covariate settings that contain cohort table settings
   # 3) a list of covariate setting that has 1 & 2 above
+  # 4) Something other than a covariate setting object
+  esModuleSettingsCreator <- EvidenceSynthesisModule$new()
+  evidenceSynthesisSourceCmGrid <- esModuleSettingsCreator$createEvidenceSynthesisSource(
+    sourceMethod = "CohortMethod",
+    likelihoodApproximation = "adaptive grid"
+  )
+
   cov1 <- FeatureExtraction::createDefaultCovariateSettings()
   cov2 <- FeatureExtraction::createCohortBasedCovariateSettings(
     analysisId = 999,
@@ -430,7 +437,8 @@ test_that("Test internal function for modifying covariate settings", {
         nested1 = cov1,
         nested2 = cov2,
         nested3 = covariateSettings
-      )
+      ),
+      esSettings = evidenceSynthesisSourceCmGrid
     )
   )
   workDatabaseSchema <- "foo"
@@ -444,6 +452,9 @@ test_that("Test internal function for modifying covariate settings", {
   )
 
   testReplacedModuleSettings <- .replaceCovariateSettings(moduleSettings, executionSettings)
+  # For visual inspection
+  #ParallelLogger::saveSettingsToJson(moduleSettings, "before_unit_test.json")
+  #ParallelLogger::saveSettingsToJson(testReplacedModuleSettings, "after_unit_test.json")
   expect_equal(testReplacedModuleSettings$analysis$something[[1]]$covariateCohortDatabaseSchema, NULL)
   expect_equal(testReplacedModuleSettings$analysis$something[[1]]$covariateCohortTable, NULL)
   expect_equal(testReplacedModuleSettings$analysis$something[[2]]$covariateCohortDatabaseSchema, workDatabaseSchema)
@@ -459,4 +470,5 @@ test_that("Test internal function for modifying covariate settings", {
   expect_equal(testReplacedModuleSettings$analysis$somethingElse$nested3[[1]]$covariateCohortTable, NULL)
   expect_equal(testReplacedModuleSettings$analysis$somethingElse$nested3[[2]]$covariateCohortDatabaseSchema, workDatabaseSchema)
   expect_equal(testReplacedModuleSettings$analysis$somethingElse$nested3[[2]]$covariateCohortTable, cohortTableNames$cohortTable)
+  expect_equal(class(testReplacedModuleSettings$analysis$esSettings), class(moduleSettings$analysis$esSettings))
 })

--- a/tests/testthat/test-Settings.R
+++ b/tests/testthat/test-Settings.R
@@ -471,4 +471,17 @@ test_that("Test internal function for modifying covariate settings", {
   expect_equal(testReplacedModuleSettings$analysis$somethingElse$nested3[[2]]$covariateCohortDatabaseSchema, workDatabaseSchema)
   expect_equal(testReplacedModuleSettings$analysis$somethingElse$nested3[[2]]$covariateCohortTable, cohortTableNames$cohortTable)
   expect_equal(class(testReplacedModuleSettings$analysis$esSettings), class(moduleSettings$analysis$esSettings))
+
+  # Additional tests for the table name replacement function
+  test1 <- .replaceCovariateSettingsCohortTableNames(covariateSettings, executionSettings)
+  expect_equal(test1[[2]]$covariateCohortDatabaseSchema, workDatabaseSchema)
+  expect_equal(test1[[2]]$covariateCohortTable, cohortTableNames$cohortTable)
+
+  test2 <- .replaceCovariateSettingsCohortTableNames(cov1, executionSettings)
+  expect_equal(test2$covariateCohortDatabaseSchema, NULL)
+  expect_equal(test2$covariateCohortTable, NULL)
+
+  test3 <- .replaceCovariateSettingsCohortTableNames(cov2, executionSettings)
+  expect_equal(test3$covariateCohortDatabaseSchema, workDatabaseSchema)
+  expect_equal(test3$covariateCohortTable, cohortTableNames$cohortTable)
 })

--- a/tests/testthat/test-Settings.R
+++ b/tests/testthat/test-Settings.R
@@ -408,3 +408,37 @@ test_that("Create results data model settings", {
 
   expect_equal(class(settings), c("ResultsDataModelSettings"))
 })
+
+test_that("Test internal function for modifying covariate settings", {
+  cov1 <- FeatureExtraction::createDefaultCovariateSettings()
+  cov2 <- FeatureExtraction::createCohortBasedCovariateSettings(
+    analysisId = 999,
+    covariateCohorts = data.frame(
+      cohortId = 1,
+      cohortName = "test"
+    )
+  )
+  covariateSettings <- list(cov1, cov2)
+  workDatabaseSchema <- "foo"
+  cohortTableNames <- CohortGenerator::getCohortTableNames(cohortTable = "unit_test")
+  executionSettings <- createCdmExecutionSettings(
+    workDatabaseSchema = workDatabaseSchema,
+    cdmDatabaseSchema = "main",
+    cohortTableNames = cohortTableNames,
+    workFolder = "temp",
+    resultsFolder = "temp"
+  )
+
+  test1 <- .replaceCovariateSettingsCohortTableNames(covariateSettings, executionSettings)
+  expect_equal(test1[[2]]$covariateCohortDatabaseSchema, workDatabaseSchema)
+  expect_equal(test1[[2]]$covariateCohortTable, cohortTableNames$cohortTable)
+
+  test2 <- .replaceCovariateSettingsCohortTableNames(cov1, executionSettings)
+  expect_equal(test2$covariateCohortDatabaseSchema, NULL)
+  expect_equal(test2$covariateCohortTable, NULL)
+
+  test3 <- .replaceCovariateSettingsCohortTableNames(cov2, executionSettings)
+  expect_equal(test3$covariateCohortDatabaseSchema, workDatabaseSchema)
+  expect_equal(test3$covariateCohortTable, cohortTableNames$cohortTable)
+
+})


### PR DESCRIPTION
Addresses #181 by adding a method to recursive check each module setting and inject the cohort schema and table from the CdmExecutionSettings when a `createCohortBasedCovariateSettings` is detected. This is handled in `StrategusModule` base class so that all modules will inherit this behavior.

