### PR TITLE
Fixing use of `unblind_for_evidence_synthesis` field (Issue 218)

### DIFF
--- a/extras/ESModule-SimulationFunctions.R
+++ b/extras/ESModule-SimulationFunctions.R
@@ -33,7 +33,7 @@ simulateTco <- function(targetId, comparatorId, outcomeId, analysisId, hazardRat
     analysisId = analysisId,
     databaseId = seq_len(nSites),
     mdrr = 2,
-    unblind = runif(nSites) < 0.9
+    unblindForEvidenceSynthesis = runif(nSites) < 0.9
   )
 
   populations <- EvidenceSynthesis::simulatePopulations(simulationSettings)
@@ -238,7 +238,7 @@ simulateEo <- function(exposureId, outcomeId, analysisId, incidenceRateRatio = 1
     analysisId = !!analysisId,
     databaseId = seq_len(nSites),
     mdrr = 2,
-    unblind = runif(nSites) < 0.9
+    unblindForEvidenceSynthesis = runif(nSites) < 0.9
   )
   DatabaseConnector::insertTable(
     connection = connection,

--- a/tests/testthat/test-EvidenceSynthesisModule.R
+++ b/tests/testthat/test-EvidenceSynthesisModule.R
@@ -140,7 +140,7 @@ getDatabaseIds <- function(setting, databaseIds) {
 
 test_that("Include only allowed CM estimates in meta-analysis", {
   # Should only include estimates in meta-analysis that are
-  # 1. Either unblinded or not outcome of interest
+  # 1. Unblinded (unblind_for_evidence_synthesis = 1)
   # 2. Has a valid estimate (normal approx) or LL profile (adaptive grid)
   # 3. Is not excluded in createEvidenceSynthesisSource()
   connection <- DatabaseConnector::connect(esTestDataConnectionDetails)
@@ -156,7 +156,7 @@ test_that("Include only allowed CM estimates in meta-analysis", {
       cm_target_comparator_outcome.outcome_id,
       analysis_id,
       database_id,
-      unblind AS include_1
+      unblind_for_evidence_synthesis AS include_1
     FROM main.cm_target_comparator_outcome
     LEFT JOIN main.cm_diagnostics_summary
       ON cm_diagnostics_summary.target_id = cm_target_comparator_outcome.target_id

--- a/tests/testthat/test-EvidenceSynthesisModule.R
+++ b/tests/testthat/test-EvidenceSynthesisModule.R
@@ -244,7 +244,7 @@ test_that("Include only allowed SCCS estimates in meta-analysis", {
       sccs_diagnostics_summary.covariate_id,
       sccs_diagnostics_summary.analysis_id,
       sccs_diagnostics_summary.database_id,
-      unblind AS include_1
+      unblind_for_evidence_synthesis AS include_1
     FROM main.sccs_exposure
     INNER JOIN main.sccs_diagnostics_summary
       ON sccs_exposure.exposures_outcome_set_id = sccs_diagnostics_summary.exposures_outcome_set_id


### PR DESCRIPTION
This fixes https://github.com/OHDSI/Strategus/issues/218, which caused the Evidence Synthesis Module to use the `unblind` field instead of the `unblind_for_evidence_synthesis` field. The problem was that the check for whether `unblind_for_evidence_synthesis` was present didn't work. I solved this by simply removing this check. All recent versions of CM and SCCS include this field.

I had to regenerate the simulated test data to change the name of the field there.

I also discovered that, both for CM and SCCS, estimates would always be included for negative controls (NCs), regardless of whether they passed diagnostics. This was from a time when only diagnostics were computed for outcomes of interest. However, recent versions of CM and SCCS evaluate diagnostics for NCs as well, and we should use those to decide whether NCs should be included in the evidence synthesis. I have changed the code accordingly.
