### PR TITLE
Forcing CohortIncidence results columns to uppercase to avoid issues …

### DIFF
--- a/R/Module-CohortIncidence.R
+++ b/R/Module-CohortIncidence.R
@@ -59,6 +59,7 @@ CohortIncidenceModule <- R6::R6Class(
       private$.message("Export data")
 
       # apply minCellCount to  executeResults
+      colnames(executeResults$incidence_summary) <- toupper(colnames(executeResults$incidence_summary))
       minCellCount <- private$jobContext$moduleExecutionSettings$minCellCount
       if (minCellCount > 0) {
         executeResults$incidence_summary <- private$.enforceMinCellValue(executeResults$incidence_summary, "PERSONS_AT_RISK_PE", minCellCount)


### PR DESCRIPTION
This fixes https://github.com/OHDSI/Strategus/issues/244

I ended up just converting the column names to upper case to have the smallest possible fix.

Note that this only affects one table in the CohortIncidenceModule. Do you think it is necessary for the other tables to maintain upper case column names? With DatabaseConnector 7 they will be lower case.