### PR TITLE
Multi-analysis specification with TreatmentPatternsModule

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,7 +58,7 @@ VignetteBuilder: knitr
 URL: https://ohdsi.github.io/Strategus, https://github.com/OHDSI/Strategus
 BugReports: https://github.com/OHDSI/Strategus/issues
 NeedsCompilation: no
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Roxygen: list(markdown = TRUE)
 Encoding: UTF-8
 Language: en-US

--- a/R/Module-TreatmentPatterns.R
+++ b/R/Module-TreatmentPatterns.R
@@ -50,141 +50,137 @@ TreatmentPatternsModule <- R6::R6Class(
       spec <- jobContext$settings
       analysisList <- jobContext$settings$tpAnalysisList
 
-      errors <- list()
+      errorMessages <- character()
+      env <- environment()
+
+
+      # checks if there are failed pathways and runs only those; if none reruns all analyses
+      resultAppend <- FALSE
+      passedPathways <- integer(0)
+
+      if (file.exists(file.path(workFolder, "passed_pathway_runs.csv")) && dir.exists(resultsFolder)) {
+        passedDf <- readr::read_csv(
+          file = file.path(workFolder, "passed_pathway_runs.csv"),
+          show_col_types = FALSE,
+          col_types = readr::cols_only(analysis_id = readr::col_integer())
+        )
+
+        passedPathways <- as.integer(passedDf$analysis_id)
+
+        file.remove(file.path(workFolder, "failed_pathway_runs.csv"))
+
+        resultAppend <- TRUE
+      }
+
       pathwayResult <- NULL
 
       for (idx in seq_along(analysisList)) {
         analysis <- analysisList[[idx]]
-        cohorts <- super$.listToDataFrame(analysis$cohorts)
+        analysisId <- analysis$analysisId
 
-        targets <- cohorts[cohorts$type == "target", c("cohortName", "cohortId"), drop = FALSE]
-        colnames(targets) <- c("target_cohort_name", "target_cohort_id")
+        if (length(passedPathways) > 0 && analysisId %in% passedPathways) {
+          private$.message(paste("Analysis", analysisId, "pathway already constructed"))
+        } else {
+          cohorts <- super$.listToDataFrame(analysis$cohorts)
 
-        events <- cohorts[cohorts$type == "event", c("cohortName", "cohortId"), drop = FALSE]
-        colnames(events) <- c("event_cohort_name", "event_cohort_id")
+          targets <- cohorts[cohorts$type == "target", c("cohortName", "cohortId"), drop = FALSE]
+          colnames(targets) <- c("target_cohort_name", "target_cohort_id")
 
-        cohortAnalysisTable <- merge(targets, events, by = NULL) %>% dplyr::mutate("analysis_id" = idx)
+          events <- cohorts[cohorts$type == "event", c("cohortName", "cohortId"), drop = FALSE]
+          colnames(events) <- c("event_cohort_name", "event_cohort_id")
 
-        tryCatch(
-          {
-            outputEnv <- TreatmentPatterns::computePathways(
-              analysisId = idx,
-              description = analysis$description,
-              cohorts = cohorts,
-              cohortTableName = jobContext$moduleExecutionSettings$cohortTableNames$cohortTable,
-              connectionDetails = connectionDetails,
-              cdmSchema = executionSettings$cdmDatabaseSchema,
-              resultSchema = executionSettings$workDatabaseSchema,
-              tempEmulationSchema = executionSettings$tempEmulationSchema,
-              startAnchor = analysis$startAnchor,
-              windowStart = analysis$windowStart,
-              endAnchor = analysis$endAnchor,
-              windowEnd = analysis$windowEnd,
-              minEraDuration = analysis$minEraDuration,
-              splitEventCohorts = analysis$splitEventCohorts,
-              splitTime = analysis$splitTime,
-              eraCollapseSize = analysis$eraCollapseSize,
-              combinationWindow = analysis$combinationWindow,
-              minPostCombinationDuration = analysis$minPostCombinationDuration,
-              filterTreatments = analysis$filterTreatments,
-              maxPathLength = analysis$maxPathLength,
-              overlapMethod = analysis$overlapMethod,
-              concatTargets = analysis$concatTargets
-            )
+          cohortAnalysisTable <- merge(targets, events, by = NULL) %>% dplyr::mutate("analysis_id" = analysisId)
 
-            result <- TreatmentPatterns::export(
-              andromeda = outputEnv,
-              outputPath = NULL,
-              ageWindow = analysis$ageWindow,
-              minCellCount = executionSettings$minCellCount,
-              censorType = analysis$censorType,
-              stratify = analysis$stratify,
-              archiveName = NULL
-            )
-
-            if (is.null(pathwayResult)) {
-              pathwayResult <- Andromeda::andromeda(
-                attrition = result$attrition,
-                metadata = result$metadata,
-                treatment_pathways = result$treatment_pathways,
-                summary_event_duration = result$summary_event_duration,
-                counts_age = result$counts_age,
-                counts_sex = result$counts_sex,
-                counts_year = result$counts_year,
-                cdm_source_info = result$cdm_source_info,
-                analyses = result$analyses,
-                arguments = result$arguments,
-                analysis_cohorts = cohortAnalysisTable
+          tryCatch(
+            {
+              outputEnv <- TreatmentPatterns::computePathways(
+                analysisId = analysisId,
+                description = analysis$description,
+                cohorts = cohorts,
+                cohortTableName = jobContext$moduleExecutionSettings$cohortTableNames$cohortTable,
+                connectionDetails = connectionDetails,
+                cdmSchema = executionSettings$cdmDatabaseSchema,
+                resultSchema = executionSettings$workDatabaseSchema,
+                tempEmulationSchema = executionSettings$tempEmulationSchema,
+                startAnchor = analysis$startAnchor,
+                windowStart = analysis$windowStart,
+                endAnchor = analysis$endAnchor,
+                windowEnd = analysis$windowEnd,
+                minEraDuration = analysis$minEraDuration,
+                splitEventCohorts = analysis$splitEventCohorts,
+                splitTime = analysis$splitTime,
+                eraCollapseSize = analysis$eraCollapseSize,
+                combinationWindow = analysis$combinationWindow,
+                minPostCombinationDuration = analysis$minPostCombinationDuration,
+                filterTreatments = analysis$filterTreatments,
+                maxPathLength = analysis$maxPathLength,
+                overlapMethod = analysis$overlapMethod,
+                concatTargets = analysis$concatTargets
               )
-            } else {
-              Andromeda::appendToTable(pathwayResult$attrition, result$attrition)
-              Andromeda::appendToTable(pathwayResult$metadata, result$metadata)
-              Andromeda::appendToTable(pathwayResult$treatment_pathways, result$treatment_pathways)
-              Andromeda::appendToTable(pathwayResult$summary_event_duration, result$summary_event_duration)
-              Andromeda::appendToTable(pathwayResult$counts_age, result$counts_age)
-              Andromeda::appendToTable(pathwayResult$counts_sex, result$counts_sex)
-              Andromeda::appendToTable(pathwayResult$counts_year, result$counts_year)
-              Andromeda::appendToTable(pathwayResult$cdm_source_info, result$cdm_source_info)
-              Andromeda::appendToTable(pathwayResult$analyses, result$analyses)
-              Andromeda::appendToTable(pathwayResult$arguments, result$arguments)
-              Andromeda::appendToTable(pathwayResult$analysis_cohorts, cohortAnalysisTable)
+
+              result <- TreatmentPatterns::export(
+                andromeda = outputEnv,
+                outputPath = NULL,
+                ageWindow = analysis$ageWindow,
+                minCellCount = executionSettings$minCellCount,
+                censorType = analysis$censorType,
+                stratify = analysis$stratify,
+                archiveName = NULL
+              )
+
+              if (is.null(pathwayResult)) {
+                pathwayResult <- Andromeda::andromeda(
+                  attrition = result$attrition,
+                  metadata = result$metadata,
+                  treatment_pathways = result$treatment_pathways,
+                  summary_event_duration = result$summary_event_duration,
+                  counts_age = result$counts_age,
+                  counts_sex = result$counts_sex,
+                  counts_year = result$counts_year,
+                  cdm_source_info = result$cdm_source_info,
+                  analyses = result$analyses,
+                  arguments = result$arguments,
+                  analysis_cohorts = cohortAnalysisTable
+                )
+              } else {
+                Andromeda::appendToTable(pathwayResult$attrition, result$attrition)
+                Andromeda::appendToTable(pathwayResult$metadata, result$metadata)
+                Andromeda::appendToTable(pathwayResult$treatment_pathways, result$treatment_pathways)
+                Andromeda::appendToTable(pathwayResult$summary_event_duration, result$summary_event_duration)
+                Andromeda::appendToTable(pathwayResult$counts_age, result$counts_age)
+                Andromeda::appendToTable(pathwayResult$counts_sex, result$counts_sex)
+                Andromeda::appendToTable(pathwayResult$counts_year, result$counts_year)
+                Andromeda::appendToTable(pathwayResult$cdm_source_info, result$cdm_source_info)
+                Andromeda::appendToTable(pathwayResult$analyses, result$analyses)
+                Andromeda::appendToTable(pathwayResult$arguments, result$arguments)
+                Andromeda::appendToTable(pathwayResult$analysis_cohorts, cohortAnalysisTable)
+              }
+
+              private$.errorHandler(file = file.path(workFolder, "passed_pathway_runs.csv"), analysisId = analysisId, targets = targets, message = "passed")
+            },
+            error = function(err) {
+              msg <- sprintf("Analysis '%s' pathway construction failed: %s", analysisId, conditionMessage(err))
+              private$.message(msg)
+
+              current <- get("errorMessages", envir = env)
+              assign("errorMessages", c(current, msg), envir = env)
+
+              private$.errorHandler(file = file.path(workFolder, "failed_pathway_runs.csv"), analysisId = analysisId, targets = targets, message = msg)
             }
-
-
-            if (file.exists(file.path(workFolder, "treatment_pathway_runs.csv"))) {
-              append <- TRUE
-            } else {
-              append <- FALSE
-            }
-
-            success <- data.frame(
-              analysis_id = idx,
-              target_names = paste(targets$target_cohort_name, collapse = ";"),
-              target_ids = paste(targets$target_cohort_id, collapse = ";"),
-              error = "Pass",
-              timestamp = Sys.time(),
-              stringsAsFactors = FALSE
-            )
-            readr::write_csv(x = success, file = file.path(workFolder, "treatment_pathway_runs.csv"), append = append)
-          },
-          error = function(err) {
-            message("Pathway for Analysis", idx, ":", conditionMessage(err))
-            errors[[length(errors) + 1]] <- sprintf("Analysis '%s' pathway construction failed: %s", idx, conditionMessage(err))
-
-
-            if (file.exists(file.path(workFolder, "treatment_pathway_runs.csv"))) {
-              append <- TRUE
-            } else {
-              append <- FALSE
-            }
-
-            error <- data.frame(
-              analysis_id = idx,
-              target_names = paste(targets$target_cohort_name, collapse = ";"),
-              target_ids = paste(targets$target_cohort_id, collapse = ";"),
-              error = errors[[length(errors)]],
-              timestamp = Sys.time(),
-              stringsAsFactors = FALSE
-            )
-
-            readr::write_csv(x = error, file = file.path(workFolder, "treatment_pathway_runs.csv"), append = append)
-          }
-        )
+          )
+        }
       }
 
-
+      # writes the results to csv
       for (name in names(pathwayResult)) {
         data <- pathwayResult[[name]] %>% dplyr::collect()
-
-        if (name != "analysis_cohorts") {
-          readr::write_csv(x = data, file = file.path(resultsFolder, paste0(name, ".csv")))
-        }
+        readr::write_csv(x = data, file = file.path(resultsFolder, paste0(self$tablePrefix, name, ".csv")), append = resultAppend)
       }
 
       # HACK: Append the database_id to all exported results
       csvFiles <- list.files(resultsFolder, pattern = "\\.csv$", full.names = TRUE)
       for (file in csvFiles) {
-        if (tools::file_path_sans_ext(basename(file)) != "analyses") {
+        if (!(tools::file_path_sans_ext(basename(file)) %in% c(paste0(self$tablePrefix, "analyses"), paste0(self$tablePrefix, "analysis_cohorts")))) {
           data <- CohortGenerator::readCsv(
             file = file
           )
@@ -197,15 +193,6 @@ TreatmentPatternsModule <- R6::R6Class(
         }
       }
 
-      data <- pathwayResult[["analysis_cohorts"]] %>% dplyr::collect()
-      readr::write_csv(x = data, file = file.path(resultsFolder, "analysis_cohorts.csv"))
-
-      csvFiles <- list.files(resultsFolder, pattern = "\\.csv$", full.names = TRUE)
-      # Rename all exported files to include the module prefix to the file name
-      for (file in csvFiles) {
-        newFileName <- file.path(resultsFolder, paste0(self$tablePrefix, basename(file)))
-        file.rename(file, newFileName)
-      }
 
       # Export the resultsDataModelSpecification.csv
       resultsDataModelSpecification <- self$getResultsDataModelSpecification()
@@ -218,13 +205,13 @@ TreatmentPatternsModule <- R6::R6Class(
         warnOnUploadRuleViolations = FALSE
       )
 
-      if (length(errors) > 0) {
+      if (length(errorMessages) > 0) {
         msg <- sprintf(
-          "Module failed: %d analysis(es) failed. See logs and per-analysis artifacts in '%s' (treatment_pathway_runs.csv)",
-          length(errors),
-          workFolder
+          "Module failed: %d analysis(es) failed. See logs and per-analysis artifacts in '%s' (failed_pathway_runs.csv). Errors: '%s'",
+          length(errorMessages),
+          workFolder,
+          paste(errorMessages, collapse = "; ")
         )
-
         stop(msg)
       }
 
@@ -281,6 +268,8 @@ TreatmentPatternsModule <- R6::R6Class(
     },
     #' @description Creates the TreatmentPatternsnModule Specifications
     #'
+    #' @param analysisId (`numeric(1)`)
+    #' Unique identifier for the TreatmentPatterns analysis
     #' @param cohorts (`data.frame()`)\cr
     #' Data frame containing the following columns and data types:
     #' \describe{
@@ -344,7 +333,8 @@ TreatmentPatternsModule <- R6::R6Class(
     #' }
     #' @param stratify (`logical(1)`)\cr
     #' This will perform pairwise stratification between age, sex, and index year if set TRUE
-    createModuleSpecifications = function(cohorts,
+    createModuleSpecifications = function(analysisId = 1,
+                                          cohorts,
                                           description = "",
                                           includeTreatments = NULL,
                                           indexDateOffset = NULL,
@@ -410,6 +400,8 @@ TreatmentPatternsModule <- R6::R6Class(
     #' @description
     #' Creates a settings list describing a TreatmentPatterns analysis. This specification is used by createMultiAnalysisModuleSpecification
     #'
+    #' @param analysisId (`numeric(1)`)
+    #' Unique identifier for the TreatmentPatterns analysis
     #' @param targetCohorts (`list()`)\cr
     #' List of target cohorts in list-of-lists form:
     #' e.g. `list(list(1, "Hypertension"), list(2, "Diabetes"))`.Each inner list must contain `cohortId` (integer) and `cohortName` (string)
@@ -483,7 +475,8 @@ TreatmentPatternsModule <- R6::R6Class(
     #'  - `cohorts`: list of cohort definitions (each item has `cohortId`,
     #'     `cohortName`, `type`)
     #'  - all parameters passed to this function (same names)
-    createAnalysisSpecification = function(targetCohorts,
+    createAnalysisSpecification = function(analysisId,
+                                           targetCohorts,
                                            eventCohorts,
                                            exitCohorts = list(),
                                            description = "",
@@ -569,16 +562,17 @@ TreatmentPatternsModule <- R6::R6Class(
       settings[["cohorts"]] <- cohorts
 
       params <- names(formals(self$createAnalysisSpecification))
-      paramsToUse <- params[-seq_len(3)]
-      for (name in paramsToUse) {
-        settings[[name]] <- get(name)
+      for (name in params) {
+        if (!(name %in% c("targetCohorts", "eventCohorts", "exitCohorts"))) {
+          settings[[name]] <- get(name)
+        }
       }
 
       return(settings)
     },
     #' @description Validate the module specifications
     #'
-    #' @param moduleSpecifications The CohortMethod module specifications
+    #' @param moduleSpecifications The treatment patterns module specifications
     validateModuleSpecifications = function(moduleSpecifications) {
       super$validateModuleSpecifications(
         moduleSpecifications = moduleSpecifications
@@ -591,6 +585,24 @@ TreatmentPatternsModule <- R6::R6Class(
         file.path("csv", "treatmentPatternsRdms.csv"),
         package = "Strategus"
       ))
+    },
+    .errorHandler = function(file, analysisId, targets, message) {
+      if (file.exists(file)) {
+        append <- TRUE
+      } else {
+        append <- FALSE
+      }
+
+      error <- data.frame(
+        analysis_id = analysisId,
+        target_names = paste(targets$target_cohort_name, collapse = ";"),
+        target_ids = paste(targets$target_cohort_id, collapse = ";"),
+        error = message,
+        timestamp = Sys.time(),
+        stringsAsFactors = FALSE
+      )
+
+      readr::write_csv(x = error, file = file, append = append)
     }
   )
 )

--- a/R/Module-TreatmentPatterns.R
+++ b/R/Module-TreatmentPatterns.R
@@ -387,10 +387,6 @@ TreatmentPatternsModule <- R6::R6Class(
     #' @param tpAnalysisList (`list()`)\cr
     #' A list of analysis specification objects.
     #' Each element should be a list created by \code{createAnalysisSpecification}
-    #' @examples
-    #' analysis1 <- createAnalysisSpecification(targetCohorts1, eventCohorts1, ...)
-    #' analysis2 <- createAnalysisSpecification(targetCohorts2, eventCohorts2, ...)
-    #' multiSpec <- createMultiAnalysisModuleSpecification(list(spec1, spec2))
     createMultiAnalysisModuleSpecification = function(tpAnalysisList) {
       specification <- super$createModuleSpecifications(
         moduleSpecifications = list(tpAnalysisList = tpAnalysisList)

--- a/R/Module-TreatmentPatterns.R
+++ b/R/Module-TreatmentPatterns.R
@@ -43,12 +43,32 @@ TreatmentPatternsModule <- R6::R6Class(
       super$.validateCdmExecutionSettings(executionSettings)
       super$execute(connectionDetails, analysisSpecifications, executionSettings)
 
+
       jobContext <- private$jobContext
       workFolder <- jobContext$moduleExecutionSettings$workSubFolder
       resultsFolder <- jobContext$moduleExecutionSettings$resultsSubFolder
 
       spec <- jobContext$settings
-      analysisList <- jobContext$settings$tpAnalysisList
+      analysisList <- spec$tpAnalysisList
+
+      if (is.null(analysisList)) {
+        settings <- list()
+        for (setting in names(spec)) {
+          settings[[setting]] <- spec[[setting]]
+        }
+
+        # new parameters(cross compatibility)
+        if (is.null(spec$analysisId)) {
+          settings[["analysisId"]] <- 1
+        }
+        if (is.null(spec$description)) {
+          settings[["description"]] <- ""
+        }
+        if (is.null(spec$stratify)) {
+          settings[["stratify"]] <- FALSE
+        }
+        analysisList <- list(settings)
+      }
 
       errorMessages <- character()
       env <- environment()
@@ -75,7 +95,12 @@ TreatmentPatternsModule <- R6::R6Class(
       pathwayResult <- NULL
 
       for (idx in seq_along(analysisList)) {
-        analysis <- analysisList[[idx]]
+        if (!is.null(analysisList[[idx]]$settings)) {
+          analysis <- analysisList[[idx]]$settings
+        } else {
+          analysis <- analysisList[[idx]]
+        }
+
         analysisId <- analysis$analysisId
 
         if (length(passedPathways) > 0 && analysisId %in% passedPathways) {
@@ -277,6 +302,13 @@ TreatmentPatternsModule <- R6::R6Class(
     #'  \item{cohortName `character(1)`}{Cohort names of the cohorts to be used in the cohort table.}
     #'  \item{type `character(1)` \["target", "event', "exit"\]}{Cohort type, describing if the cohort is a target, event, or exit cohort}
     #' }
+    #' @param targetCohorts (`list()`)\cr
+    #' List of target cohorts in list-of-lists form:
+    #' e.g. `list(list(1, "Hypertension"), list(2, "Diabetes"))`.Each inner list must contain `cohortId` (integer) and `cohortName` (string)
+    #' @param eventCohorts (`list()`)\cr
+    #' Same structure as `targetCohorts`. These cohorts are treated as events/treatments
+    #' @param exitCohorts (`list()`)\cr
+    #' Same structure; if provided these are treated as exit cohorts
     #' @param description (`character(1)`)
     #' Description for analysis
     #' @param minEraDuration (`integer(1)`: `0`)\cr
@@ -334,7 +366,10 @@ TreatmentPatternsModule <- R6::R6Class(
     #' @param stratify (`logical(1)`)\cr
     #' This will perform pairwise stratification between age, sex, and index year if set TRUE
     createModuleSpecifications = function(analysisId = 1,
-                                          cohorts,
+                                          cohorts = NULL,
+                                          targetCohorts = NULL,
+                                          eventCohorts = NULL,
+                                          exitCohorts = NULL,
                                           description = "",
                                           includeTreatments = NULL,
                                           indexDateOffset = NULL,
@@ -364,158 +399,37 @@ TreatmentPatternsModule <- R6::R6Class(
         warning("`includeTreatments` is deprecated in TreatentPatterns 3.1.0, please use: `startAnchor`, `windowStart`, `endAnchor`, `windowEnd` instead.")
       }
 
-      settings <- list()
-      for (name in names(formals(self$createModuleSpecifications))) {
-        if (name == "cohorts") {
-          settings[[name]] <- super$.dataFrameToList(get(name))
-        } else {
-          settings[[name]] <- get(name)
+      if (is.null(cohorts) && (is.null(targetCohorts) | is.null(eventCohorts))) {
+        stop(sprintf("specify cohort or targetCohorts and eventCohorts"))
+      }
+
+      # construct cohorts
+      if (is.null(cohorts)) {
+        targetCohorts <- as.data.frame(do.call(rbind, targetCohorts), stringsAsFactors = FALSE) %>% dplyr::mutate(type = "target")
+        eventCohorts <- as.data.frame(do.call(rbind, eventCohorts), stringsAsFactors = FALSE) %>% dplyr::mutate(type = "event")
+        exitCohorts <- if (length(exitCohorts) > 0) {
+          exitCohorts <- as.data.frame(do.call(rbind, exitCohorts), stringsAsFactors = FALSE) %>% dplyr::mutate(type = "exit")
         }
+
+        if (!is.null(exitCohorts) && nrow(exitCohorts) > 0) {
+          cohorts <- dplyr::bind_rows(targetCohorts, eventCohorts, exitCohorts)
+        } else {
+          cohorts <- dplyr::bind_rows(targetCohorts, eventCohorts)
+        }
+
+        colnames(cohorts) <- c("cohortId", "cohortName", "type")
+        cohorts$cohortId <- as.integer(cohorts$cohortId)
+        cohorts$cohortName <- as.character(cohorts$cohortName)
+        cohorts$type <- as.character(cohorts$type)
       }
 
-      analysis <- list(tpAnalysisList = list(settings))
-
-      specification <- super$createModuleSpecifications(
-        moduleSpecifications = analysis
-      )
-
-      return(specification)
-    },
-    #' @description
-    #' Runs multiple analyses using a list of analysis specification objects (as produced by\code{createAnalysisSpecification}) into a single module specification
-    #'
-    #' @param tpAnalysisList (`list()`)\cr
-    #' A list of analysis specification objects.
-    #' Each element should be a list created by \code{createAnalysisSpecification}
-    createMultiAnalysisModuleSpecification = function(tpAnalysisList) {
-      specification <- super$createModuleSpecifications(
-        moduleSpecifications = list(tpAnalysisList = tpAnalysisList)
-      )
-      return(specification)
-    },
-    #' @description
-    #' Creates a settings list describing a TreatmentPatterns analysis. This specification is used by createMultiAnalysisModuleSpecification
-    #'
-    #' @param analysisId (`numeric(1)`)
-    #' Unique identifier for the TreatmentPatterns analysis
-    #' @param targetCohorts (`list()`)\cr
-    #' List of target cohorts in list-of-lists form:
-    #' e.g. `list(list(1, "Hypertension"), list(2, "Diabetes"))`.Each inner list must contain `cohortId` (integer) and `cohortName` (string)
-    #' @param eventCohorts (`list()`)\cr
-    #' Same structure as `targetCohorts`. These cohorts are treated as events/treatments
-    #' @param exitCohorts (`list()`)\cr
-    #' Same structure; if provided these are treated as exit cohorts
-    #' @param description (`character(1)`)\cr
-    #' Description for analysis
-    #' @param minEraDuration (`integer(1)`: `0`)\cr
-    #' Minimum time an event era should last to be included in analysis
-    #' @param splitEventCohorts (`character(n)`: `""`)\cr
-    #' Specify event cohort to split in acute (< X days) and therapy (>= X days)
-    #' @param splitTime (`integer(1)`: `30`)\cr
-    #' Specify number of days (X) at which each of the split event cohorts should
-    #' be split in acute and therapy
-    #' @param eraCollapseSize (`integer(1)`: `30`)\cr
-    #' Window of time between which two eras of the same event cohort are collapsed
-    #' into one era
-    #' @param combinationWindow (`integer(1)`: `30`)\cr
-    #' Window of time two event cohorts need to overlap to be considered a
-    #' combination treatment
-    #' @param minPostCombinationDuration (`integer(1)`: `30`)\cr
-    #' Minimum time an event era before or after a generated combination treatment
-    #' should last to be included in analysis
-    #' @param filterTreatments (`character(1)`: `"First"` \["first", "Changes", "all"\])\cr
-    #' Select first occurrence of (‘First’); changes between (‘Changes’); or all
-    #' event cohorts (‘All’).
-    #' @param maxPathLength (`integer(1)`: `5`)\cr
-    #' Maximum number of steps included in treatment pathway
-    #' @param ageWindow (`integer(n)`: `10`)\cr
-    #' Number of years to bin age groups into. It may also be a vector of integers.
-    #' I.e. `c(0, 18, 150)` which will results in age group `0-18` which includes
-    #' subjects `< 19`. And age group `18-150` which includes subjects `> 18`.
-    #' @param minCellCount (`integer(1)`: `5`)\cr
-    #' Minimum count required per pathway. Censors data below `x` as `<x`. This
-    #' minimum value will carry over to the sankey diagram and sunburst plot.
-    #' @param censorType (`character(1)`)\cr
-    #' \describe{
-    #'   \item{`"minCellCount"`}{Censors pathways <`minCellCount` to `minCellCount`.}
-    #'   \item{`"remove"`}{Censors pathways <`minCellCount` by removing them completely.}
-    #'   \item{`"mean"`}{Censors pathways <`minCellCount` to the mean of all frequencies below `minCellCount`}
-    #' }
-    #' @param overlapMethod (`character(1)`: `"truncate"`) Method to decide how to deal
-    #' with overlap that is not significant enough for combination. `"keep"` will
-    #' keep the dates as is. `"truncate"` truncates the first occurring event to
-    #' the start date of the next event.
-    #' @param concatTargets (`logical(1)`: `TRUE`) Should multiple target cohorts for the same person be concatenated or not?
-    #' @param startAnchor (`character(1)`: `"startDate"`) Start date anchor. One of: `"startDate"`, `"endDate"`
-    #' @param windowStart (`numeric(1)`: `0`) Offset for `startAnchor` in days.
-    #' @param endAnchor (`character(1)`: `"endDate"`) End date anchor. One of: `"startDate"`, `"endDate"`
-    #' @param windowEnd (`numeric(1)`: `0`) Offset for `endAnchor` in days.
-    #' @param indexDateOffset (`integer(1)`: `0`)\cr
-    #' `DEPRECATED`
-    #' Offset the index date of the `Target` cohort.
-    #' @param includeTreatments (`character(1)`: `"startDate"`)\cr
-    #' `DEPRECATED`
-    #' \describe{
-    #'  \item{`"startDate"`}{Include treatments after the target cohort start date and onwards.}
-    #'  \item{`"endDate"`}{Include treatments before target cohort end date and before.}
-    #' }
-    #' @param stratify (`logical(1)`)\cr
-    #' This will perform pairwise stratification between age, sex, and index year if set TRUE
-    #'
-    #' @details
-    #' - cohortName must not contain `-` or `+`. Cohort names are validated as
-    #'   (perl-compatible) regular expressions. If invalid, an informative error is
-    #'   raised.
-    #'
-    #' @return A `list` describing analysis settings. Keys include:
-    #'  - `cohorts`: list of cohort definitions (each item has `cohortId`,
-    #'     `cohortName`, `type`)
-    #'  - all parameters passed to this function (same names)
-    createAnalysisSpecification = function(analysisId,
-                                           targetCohorts,
-                                           eventCohorts,
-                                           exitCohorts = list(),
-                                           description = "",
-                                           includeTreatments = NULL,
-                                           indexDateOffset = NULL,
-                                           minEraDuration = 0,
-                                           splitEventCohorts = NULL,
-                                           splitTime = NULL,
-                                           eraCollapseSize = 30,
-                                           combinationWindow = 30,
-                                           minPostCombinationDuration = 30,
-                                           filterTreatments = "First",
-                                           maxPathLength = 5,
-                                           ageWindow = 5,
-                                           minCellCount = 1,
-                                           censorType = "minCellCount",
-                                           overlapMethod = "truncate",
-                                           concatTargets = TRUE,
-                                           startAnchor = "startDate",
-                                           windowStart = 0,
-                                           endAnchor = "endDate",
-                                           windowEnd = 0,
-                                           stratify = FALSE) {
-      if (!is.null(indexDateOffset)) {
-        warning("`indexDateOffset` is deprecated in TreatmentPatterns 3.1.0, please use: `startAnchor`, `windowStart`, `endAnchor`, `windowEnd` instead.")
-      }
-
-      if (!is.null(includeTreatments)) {
-        warning("`includeTreatments` is deprecated in TreatentPatterns 3.1.0, please use: `startAnchor`, `windowStart`, `endAnchor`, `windowEnd` instead.")
-      }
-
-      if (is.null(targetCohorts) | is.null(eventCohorts)) {
-        stop(sprintf("targetCohorts or eventCohorts are empty"))
-      }
-
-      # validate target names
-      for (cohort in c(targetCohorts, eventCohorts, exitCohorts)) {
-        pattern <- cohort[[2]]
+      # validate user input
+      for (cohort in cohorts$cohortName) {
         tryCatch(
           {
             # Attempt to compile the regex by running grepl on an empty string
-            grepl(pattern, "", perl = TRUE)
-            if (grepl("[-+]", pattern, perl = TRUE)) {
+            grepl(cohort, "", perl = TRUE)
+            if (grepl("[-+]", cohort, perl = TRUE)) {
               stop(sprintf("Invalid target cohort name; remove -/+"))
             }
           },
@@ -523,7 +437,7 @@ TreatmentPatternsModule <- R6::R6Class(
             stop(
               sprintf(
                 "Invalid target cohort name '%s': %s",
-                pattern, e$message
+                cohort, e$message
               ),
               call. = FALSE
             )
@@ -531,40 +445,39 @@ TreatmentPatternsModule <- R6::R6Class(
         )
       }
 
-      targetCohorts <- as.data.frame(do.call(rbind, targetCohorts), stringsAsFactors = FALSE) %>% dplyr::mutate(type = "target")
+      analysis <- list()
+      analysis[["cohorts"]] <- super$.dataFrameToList(cohorts)
 
-      eventCohorts <- as.data.frame(do.call(rbind, eventCohorts), stringsAsFactors = FALSE) %>% dplyr::mutate(type = "event")
-
-      exitCohorts <- if (length(exitCohorts) > 0) {
-        exitCohorts <- as.data.frame(do.call(rbind, exitCohorts), stringsAsFactors = FALSE) %>% dplyr::mutate(type = "exit")
-      }
-
-
-      if (!is.null(exitCohorts) && nrow(exitCohorts) > 0) {
-        cohorts <- dplyr::bind_rows(targetCohorts, eventCohorts, exitCohorts)
-      } else {
-        cohorts <- dplyr::bind_rows(targetCohorts, eventCohorts)
-      }
-
-      colnames(cohorts) <- c("cohortId", "cohortName", "type")
-
-      cohorts$cohortId <- as.integer(cohorts$cohortId)
-      cohorts$cohortName <- as.character(cohorts$cohortName)
-      cohorts$type <- as.character(cohorts$type)
-
-      cohorts <- super$.dataFrameToList(cohorts)
-
-      settings <- list()
-      settings[["cohorts"]] <- cohorts
-
-      params <- names(formals(self$createAnalysisSpecification))
-      for (name in params) {
-        if (!(name %in% c("targetCohorts", "eventCohorts", "exitCohorts"))) {
-          settings[[name]] <- get(name)
+      for (name in names(formals(self$createModuleSpecifications))) {
+        if (!(name %in% c("cohorts", "targetCohorts", "eventCohorts", "exitCohorts"))) {
+          analysis[[name]] <- get(name)
         }
       }
 
-      return(settings)
+      specification <- super$createModuleSpecifications(analysis)
+
+      return(specification)
+    },
+    #' @description
+    #' Runs multiple analyses using a list of analysis specification objects (as produced by\code{createModuleSpecifications}) into a single module specification
+    #'
+    #' @param tpAnalysisList (`list()`)\cr
+    #' A list of analysis specification objects.
+    #' Each element should be a list created by \code{createAnalysisSpecification}
+    createMultiAnalysisModuleSpecification = function(tpAnalysisList) {
+      analysisIds <- list()
+      for (analysis in tpAnalysisList) {
+        analysisIds[[length(analysisIds) + 1]] <- analysis$settings$analysisId
+      }
+
+      if (anyDuplicated(analysisIds)) {
+        stop("Each analysis need unique id")
+      }
+
+      specification <- super$createModuleSpecifications(
+        moduleSpecifications = list(tpAnalysisList = tpAnalysisList)
+      )
+      return(specification)
     },
     #' @description Validate the module specifications
     #'

--- a/R/Module-TreatmentPatterns.R
+++ b/R/Module-TreatmentPatterns.R
@@ -131,7 +131,7 @@ TreatmentPatternsModule <- R6::R6Class(
             }
 
 
-            if (file.exists(file.path(workFolder, "success_summary.csv"))) {
+            if (file.exists(file.path(workFolder, "treatment_pathway_runs.csv"))) {
               append <- TRUE
             } else {
               append <- FALSE
@@ -141,17 +141,18 @@ TreatmentPatternsModule <- R6::R6Class(
               analysis_id = idx,
               target_names = paste(targets$target_cohort_name, collapse = ";"),
               target_ids = paste(targets$target_cohort_id, collapse = ";"),
+              error = "Pass",
               timestamp = Sys.time(),
               stringsAsFactors = FALSE
             )
-            readr::write_csv(x = success, file = file.path(workFolder, "success_summary.csv"), append = append)
+            readr::write_csv(x = success, file = file.path(workFolder, "treatment_pathway_runs.csv"), append = append)
           },
           error = function(err) {
             message("Pathway for Analysis", idx, ":", conditionMessage(err))
             errors[[length(errors) + 1]] <- sprintf("Analysis '%s' pathway construction failed: %s", idx, conditionMessage(err))
 
 
-            if (file.exists(file.path(workFolder, "errors_summary.csv"))) {
+            if (file.exists(file.path(workFolder, "treatment_pathway_runs.csv"))) {
               append <- TRUE
             } else {
               append <- FALSE
@@ -166,7 +167,7 @@ TreatmentPatternsModule <- R6::R6Class(
               stringsAsFactors = FALSE
             )
 
-            readr::write_csv(x = error, file = file.path(workFolder, "errors_summary.csv"), append = append)
+            readr::write_csv(x = error, file = file.path(workFolder, "treatment_pathway_runs.csv"), append = append)
           }
         )
       }
@@ -219,7 +220,7 @@ TreatmentPatternsModule <- R6::R6Class(
 
       if (length(errors) > 0) {
         msg <- sprintf(
-          "Module failed: %d analysis(es) failed. See logs and per-analysis artifacts in '%s' (errors_summary.csv)",
+          "Module failed: %d analysis(es) failed. See logs and per-analysis artifacts in '%s' (treatment_pathway_runs.csv)",
           length(errors),
           workFolder
         )

--- a/R/Module-TreatmentPatterns.R
+++ b/R/Module-TreatmentPatterns.R
@@ -77,7 +77,7 @@ TreatmentPatternsModule <- R6::R6Class(
       resultAppend <- FALSE
 
       passedPathways <- integer(0)
-      if (executionSettings$incremental && file.exists(file.path(workFolder, "passed_pathway_runs.csv")) && dir.exists(resultsFolder)) {
+      if (isTRUE(executionSettings$incremental) && file.exists(file.path(workFolder, "passed_pathway_runs.csv")) && dir.exists(resultsFolder)) {
         passedDf <- readr::read_csv(
           file = file.path(workFolder, "passed_pathway_runs.csv"),
           show_col_types = FALSE,
@@ -190,6 +190,11 @@ TreatmentPatternsModule <- R6::R6Class(
         }
       }
 
+      if (isFALSE(resultAppend)){
+        unlink(resultsFolder, recursive = TRUE)
+        dir.create(resultsFolder, recursive = TRUE, showWarnings = FALSE)
+      }
+
       # writes the results to csv
       for (name in names(pathwayResult)) {
         data <- pathwayResult[[name]] %>% dplyr::collect()
@@ -198,6 +203,7 @@ TreatmentPatternsModule <- R6::R6Class(
         if(name == "analysisCohorts"){
           colnames(data) <- SqlRender::camelCaseToSnakeCase(colnames(data))
         }
+
         readr::write_csv(x = data, file = file.path(resultsFolder, paste0(self$tablePrefix, snakeCaseName, ".csv")), append = resultAppend)
       }
 

--- a/R/Module-TreatmentPatterns.R
+++ b/R/Module-TreatmentPatterns.R
@@ -43,7 +43,6 @@ TreatmentPatternsModule <- R6::R6Class(
       super$.validateCdmExecutionSettings(executionSettings)
       super$execute(connectionDetails, analysisSpecifications, executionSettings)
 
-
       jobContext <- private$jobContext
       workFolder <- jobContext$moduleExecutionSettings$workSubFolder
       resultsFolder <- jobContext$moduleExecutionSettings$resultsSubFolder
@@ -76,9 +75,9 @@ TreatmentPatternsModule <- R6::R6Class(
 
       # checks if there are failed pathways and runs only those; if none reruns all analyses
       resultAppend <- FALSE
-      passedPathways <- integer(0)
 
-      if (file.exists(file.path(workFolder, "passed_pathway_runs.csv")) && dir.exists(resultsFolder)) {
+      passedPathways <- integer(0)
+      if (executionSettings$incremental && file.exists(file.path(workFolder, "passed_pathway_runs.csv")) && dir.exists(resultsFolder)) {
         passedDf <- readr::read_csv(
           file = file.path(workFolder, "passed_pathway_runs.csv"),
           show_col_types = FALSE,
@@ -109,13 +108,8 @@ TreatmentPatternsModule <- R6::R6Class(
           cohorts <- super$.listToDataFrame(analysis$cohorts)
 
           targets <- cohorts[cohorts$type == "target", c("cohortName", "cohortId"), drop = FALSE]
-          colnames(targets) <- c("target_cohort_name", "target_cohort_id")
 
-          events <- cohorts[cohorts$type == "event", c("cohortName", "cohortId"), drop = FALSE]
-          colnames(events) <- c("event_cohort_name", "event_cohort_id")
-
-          cohortAnalysisTable <- merge(targets, events, by = NULL) %>% dplyr::mutate("analysis_id" = analysisId)
-
+          cohortAnalysisTable <- cohorts %>% dplyr::mutate("analysisId" = analysisId)
           tryCatch(
             {
               outputEnv <- TreatmentPatterns::computePathways(
@@ -157,28 +151,28 @@ TreatmentPatternsModule <- R6::R6Class(
                 pathwayResult <- Andromeda::andromeda(
                   attrition = result$attrition,
                   metadata = result$metadata,
-                  treatment_pathways = result$treatment_pathways,
-                  summary_event_duration = result$summary_event_duration,
-                  counts_age = result$counts_age,
-                  counts_sex = result$counts_sex,
-                  counts_year = result$counts_year,
-                  cdm_source_info = result$cdm_source_info,
+                  treatmentPathways = result$treatment_pathways,
+                  summaryEventDuration = result$summary_event_duration,
+                  countsAge = result$counts_age,
+                  countsSex = result$counts_sex,
+                  countsYear = result$counts_year,
+                  cdmSourceInfo = result$cdm_source_info,
                   analyses = result$analyses,
                   arguments = result$arguments,
-                  analysis_cohorts = cohortAnalysisTable
+                  analysisCohorts = cohortAnalysisTable
                 )
               } else {
                 Andromeda::appendToTable(pathwayResult$attrition, result$attrition)
                 Andromeda::appendToTable(pathwayResult$metadata, result$metadata)
-                Andromeda::appendToTable(pathwayResult$treatment_pathways, result$treatment_pathways)
-                Andromeda::appendToTable(pathwayResult$summary_event_duration, result$summary_event_duration)
-                Andromeda::appendToTable(pathwayResult$counts_age, result$counts_age)
-                Andromeda::appendToTable(pathwayResult$counts_sex, result$counts_sex)
-                Andromeda::appendToTable(pathwayResult$counts_year, result$counts_year)
-                Andromeda::appendToTable(pathwayResult$cdm_source_info, result$cdm_source_info)
+                Andromeda::appendToTable(pathwayResult$treatmentPathways, result$treatment_pathways)
+                Andromeda::appendToTable(pathwayResult$summaryEventDuration, result$summary_event_duration)
+                Andromeda::appendToTable(pathwayResult$countsAge, result$counts_age)
+                Andromeda::appendToTable(pathwayResult$countsSex, result$counts_sex)
+                Andromeda::appendToTable(pathwayResult$countsYear, result$counts_year)
+                Andromeda::appendToTable(pathwayResult$cdmSourceInfo, result$cdm_source_info)
                 Andromeda::appendToTable(pathwayResult$analyses, result$analyses)
                 Andromeda::appendToTable(pathwayResult$arguments, result$arguments)
-                Andromeda::appendToTable(pathwayResult$analysis_cohorts, cohortAnalysisTable)
+                Andromeda::appendToTable(pathwayResult$analysisCohorts, cohortAnalysisTable)
               }
 
               private$.errorHandler(file = file.path(workFolder, "passed_pathway_runs.csv"), analysisId = analysisId, targets = targets, message = "passed")
@@ -199,7 +193,12 @@ TreatmentPatternsModule <- R6::R6Class(
       # writes the results to csv
       for (name in names(pathwayResult)) {
         data <- pathwayResult[[name]] %>% dplyr::collect()
-        readr::write_csv(x = data, file = file.path(resultsFolder, paste0(self$tablePrefix, name, ".csv")), append = resultAppend)
+        snakeCaseName = SqlRender::camelCaseToSnakeCase(name)
+
+        if(name == "analysisCohorts"){
+          colnames(data) <- SqlRender::camelCaseToSnakeCase(colnames(data))
+        }
+        readr::write_csv(x = data, file = file.path(resultsFolder, paste0(self$tablePrefix, snakeCaseName, ".csv")), append = resultAppend)
       }
 
       # HACK: Append the database_id to all exported results
@@ -302,13 +301,6 @@ TreatmentPatternsModule <- R6::R6Class(
     #'  \item{cohortName `character(1)`}{Cohort names of the cohorts to be used in the cohort table.}
     #'  \item{type `character(1)` \["target", "event', "exit"\]}{Cohort type, describing if the cohort is a target, event, or exit cohort}
     #' }
-    #' @param targetCohorts (`list()`)\cr
-    #' List of target cohorts in list-of-lists form:
-    #' e.g. `list(list(1, "Hypertension"), list(2, "Diabetes"))`.Each inner list must contain `cohortId` (integer) and `cohortName` (string)
-    #' @param eventCohorts (`list()`)\cr
-    #' Same structure as `targetCohorts`. These cohorts are treated as events/treatments
-    #' @param exitCohorts (`list()`)\cr
-    #' Same structure; if provided these are treated as exit cohorts
     #' @param description (`character(1)`)
     #' Description for analysis
     #' @param minEraDuration (`integer(1)`: `0`)\cr
@@ -366,10 +358,7 @@ TreatmentPatternsModule <- R6::R6Class(
     #' @param stratify (`logical(1)`)\cr
     #' This will perform pairwise stratification between age, sex, and index year if set TRUE
     createModuleSpecifications = function(analysisId = 1,
-                                          cohorts = NULL,
-                                          targetCohorts = NULL,
-                                          eventCohorts = NULL,
-                                          exitCohorts = NULL,
+                                          cohorts,
                                           description = "",
                                           includeTreatments = NULL,
                                           indexDateOffset = NULL,
@@ -399,30 +388,6 @@ TreatmentPatternsModule <- R6::R6Class(
         warning("`includeTreatments` is deprecated in TreatentPatterns 3.1.0, please use: `startAnchor`, `windowStart`, `endAnchor`, `windowEnd` instead.")
       }
 
-      if (is.null(cohorts) && (is.null(targetCohorts) | is.null(eventCohorts))) {
-        stop(sprintf("specify cohort or targetCohorts and eventCohorts"))
-      }
-
-      # construct cohorts
-      if (is.null(cohorts)) {
-        targetCohorts <- as.data.frame(do.call(rbind, targetCohorts), stringsAsFactors = FALSE) %>% dplyr::mutate(type = "target")
-        eventCohorts <- as.data.frame(do.call(rbind, eventCohorts), stringsAsFactors = FALSE) %>% dplyr::mutate(type = "event")
-        exitCohorts <- if (length(exitCohorts) > 0) {
-          exitCohorts <- as.data.frame(do.call(rbind, exitCohorts), stringsAsFactors = FALSE) %>% dplyr::mutate(type = "exit")
-        }
-
-        if (!is.null(exitCohorts) && nrow(exitCohorts) > 0) {
-          cohorts <- dplyr::bind_rows(targetCohorts, eventCohorts, exitCohorts)
-        } else {
-          cohorts <- dplyr::bind_rows(targetCohorts, eventCohorts)
-        }
-
-        colnames(cohorts) <- c("cohortId", "cohortName", "type")
-        cohorts$cohortId <- as.integer(cohorts$cohortId)
-        cohorts$cohortName <- as.character(cohorts$cohortName)
-        cohorts$type <- as.character(cohorts$type)
-      }
-
       # validate user input
       for (cohort in cohorts$cohortName) {
         tryCatch(
@@ -449,7 +414,7 @@ TreatmentPatternsModule <- R6::R6Class(
       analysis[["cohorts"]] <- super$.dataFrameToList(cohorts)
 
       for (name in names(formals(self$createModuleSpecifications))) {
-        if (!(name %in% c("cohorts", "targetCohorts", "eventCohorts", "exitCohorts"))) {
+        if (!(name %in% c("cohorts"))) {
           analysis[[name]] <- get(name)
         }
       }

--- a/R/Module-TreatmentPatterns.R
+++ b/R/Module-TreatmentPatterns.R
@@ -48,46 +48,137 @@ TreatmentPatternsModule <- R6::R6Class(
       resultsFolder <- jobContext$moduleExecutionSettings$resultsSubFolder
 
       spec <- jobContext$settings
-      cohorts <- super$.listToDataFrame(spec$cohorts)
+      analysisList <- jobContext$settings$tpAnalysisList
 
-      outputEnv <- TreatmentPatterns::computePathways(
-        cohorts = cohorts,
-        cohortTableName = jobContext$moduleExecutionSettings$cohortTableNames$cohortTable,
-        connectionDetails = connectionDetails,
-        cdmSchema = executionSettings$cdmDatabaseSchema,
-        resultSchema = executionSettings$workDatabaseSchema,
-        tempEmulationSchema = executionSettings$tempEmulationSchema,
-        startAnchor = spec$startAnchor,
-        windowStart = spec$windowStart,
-        endAnchor = spec$endAnchor,
-        windowEnd = spec$windowEnd,
-        minEraDuration = spec$minEraDuration,
-        splitEventCohorts = spec$splitEventCohorts,
-        splitTime = spec$splitTime,
-        eraCollapseSize = spec$eraCollapseSize,
-        combinationWindow = spec$combinationWindow,
-        minPostCombinationDuration = spec$minPostCombinationDuration,
-        filterTreatments = spec$filterTreatments,
-        maxPathLength = spec$maxPathLength,
-        overlapMethod = spec$overlapMethod,
-        concatTargets = spec$concatTargets
-      )
+      errors <- list()
+      pathwayResult <- NULL
 
-      TreatmentPatterns::export(
-        andromeda = outputEnv,
-        outputPath = resultsFolder,
-        ageWindow = spec$ageWindow,
-        minCellCount = executionSettings$minCellCount,
-        censorType = spec$censorType,
-        archiveName = NULL
-      )
+      for (idx in seq_along(analysisList)) {
+        analysis <- analysisList[[idx]]
+        cohorts <- super$.listToDataFrame(analysis$cohorts)
 
-      on.exit(
-        Andromeda::saveAndromeda(
-          andromeda = outputEnv,
-          fileName = file.path(workFolder, "outputEnv")
+        targets <- cohorts[cohorts$type == "target", c("cohortName", "cohortId"), drop = FALSE]
+        colnames(targets) <- c("target_cohort_name", "target_cohort_id")
+
+        events <- cohorts[cohorts$type == "event", c("cohortName", "cohortId"), drop = FALSE]
+        colnames(events) <- c("event_cohort_name", "event_cohort_id")
+
+        cohortAnalysisTable <- merge(targets, events, by = NULL) %>% dplyr::mutate("analysis_id" = idx)
+
+        tryCatch(
+          {
+            outputEnv <- TreatmentPatterns::computePathways(
+              analysisId = idx,
+              description = analysis$description,
+              cohorts = cohorts,
+              cohortTableName = jobContext$moduleExecutionSettings$cohortTableNames$cohortTable,
+              connectionDetails = connectionDetails,
+              cdmSchema = executionSettings$cdmDatabaseSchema,
+              resultSchema = executionSettings$workDatabaseSchema,
+              tempEmulationSchema = executionSettings$tempEmulationSchema,
+              startAnchor = analysis$startAnchor,
+              windowStart = analysis$windowStart,
+              endAnchor = analysis$endAnchor,
+              windowEnd = analysis$windowEnd,
+              minEraDuration = analysis$minEraDuration,
+              splitEventCohorts = analysis$splitEventCohorts,
+              splitTime = analysis$splitTime,
+              eraCollapseSize = analysis$eraCollapseSize,
+              combinationWindow = analysis$combinationWindow,
+              minPostCombinationDuration = analysis$minPostCombinationDuration,
+              filterTreatments = analysis$filterTreatments,
+              maxPathLength = analysis$maxPathLength,
+              overlapMethod = analysis$overlapMethod,
+              concatTargets = analysis$concatTargets
+            )
+
+            result <- TreatmentPatterns::export(
+              andromeda = outputEnv,
+              outputPath = NULL,
+              ageWindow = analysis$ageWindow,
+              minCellCount = executionSettings$minCellCount,
+              censorType = analysis$censorType,
+              stratify = analysis$stratify,
+              archiveName = NULL
+            )
+
+            if (is.null(pathwayResult)) {
+              pathwayResult <- Andromeda::andromeda(
+                attrition = result$attrition,
+                metadata = result$metadata,
+                treatment_pathways = result$treatment_pathways,
+                summary_event_duration = result$summary_event_duration,
+                counts_age = result$counts_age,
+                counts_sex = result$counts_sex,
+                counts_year = result$counts_year,
+                cdm_source_info = result$cdm_source_info,
+                analyses = result$analyses,
+                arguments = result$arguments,
+                analysis_cohorts = cohortAnalysisTable
+              )
+            } else {
+              Andromeda::appendToTable(pathwayResult$attrition, result$attrition)
+              Andromeda::appendToTable(pathwayResult$metadata, result$metadata)
+              Andromeda::appendToTable(pathwayResult$treatment_pathways, result$treatment_pathways)
+              Andromeda::appendToTable(pathwayResult$summary_event_duration, result$summary_event_duration)
+              Andromeda::appendToTable(pathwayResult$counts_age, result$counts_age)
+              Andromeda::appendToTable(pathwayResult$counts_sex, result$counts_sex)
+              Andromeda::appendToTable(pathwayResult$counts_year, result$counts_year)
+              Andromeda::appendToTable(pathwayResult$cdm_source_info, result$cdm_source_info)
+              Andromeda::appendToTable(pathwayResult$analyses, result$analyses)
+              Andromeda::appendToTable(pathwayResult$arguments, result$arguments)
+              Andromeda::appendToTable(pathwayResult$analysis_cohorts, cohortAnalysisTable)
+            }
+
+
+            if (file.exists(file.path(workFolder, "success_summary.csv"))) {
+              append <- TRUE
+            } else {
+              append <- FALSE
+            }
+
+            success <- data.frame(
+              analysis_id = idx,
+              target_names = paste(targets$target_cohort_name, collapse = ";"),
+              target_ids = paste(targets$target_cohort_id, collapse = ";"),
+              timestamp = Sys.time(),
+              stringsAsFactors = FALSE
+            )
+            readr::write_csv(x = success, file = file.path(workFolder, "success_summary.csv"), append = append)
+          },
+          error = function(err) {
+            message("Pathway for Analysis", idx, ":", conditionMessage(err))
+            errors[[length(errors) + 1]] <- sprintf("Analysis '%s' pathway construction failed: %s", idx, conditionMessage(err))
+
+
+            if (file.exists(file.path(workFolder, "errors_summary.csv"))) {
+              append <- TRUE
+            } else {
+              append <- FALSE
+            }
+
+            error <- data.frame(
+              analysis_id = idx,
+              target_names = paste(targets$target_cohort_name, collapse = ";"),
+              target_ids = paste(targets$target_cohort_id, collapse = ";"),
+              error = errors[[length(errors)]],
+              timestamp = Sys.time(),
+              stringsAsFactors = FALSE
+            )
+
+            readr::write_csv(x = error, file = file.path(workFolder, "errors_summary.csv"), append = append)
+          }
         )
-      )
+      }
+
+
+      for (name in names(pathwayResult)) {
+        data <- pathwayResult[[name]] %>% dplyr::collect()
+
+        if (name != "analysis_cohorts") {
+          readr::write_csv(x = data, file = file.path(resultsFolder, paste0(name, ".csv")))
+        }
+      }
 
       # HACK: Append the database_id to all exported results
       csvFiles <- list.files(resultsFolder, pattern = "\\.csv$", full.names = TRUE)
@@ -105,6 +196,10 @@ TreatmentPatternsModule <- R6::R6Class(
         }
       }
 
+      data <- pathwayResult[["analysis_cohorts"]] %>% dplyr::collect()
+      readr::write_csv(x = data, file = file.path(resultsFolder, "analysis_cohorts.csv"))
+
+      csvFiles <- list.files(resultsFolder, pattern = "\\.csv$", full.names = TRUE)
       # Rename all exported files to include the module prefix to the file name
       for (file in csvFiles) {
         newFileName <- file.path(resultsFolder, paste0(self$tablePrefix, basename(file)))
@@ -121,6 +216,16 @@ TreatmentPatternsModule <- R6::R6Class(
         warnOnFileNameCaseMismatch = FALSE,
         warnOnUploadRuleViolations = FALSE
       )
+
+      if (length(errors) > 0) {
+        msg <- sprintf(
+          "Module failed: %d analysis(es) failed. See logs and per-analysis artifacts in '%s' (errors_summary.csv)",
+          length(errors),
+          workFolder
+        )
+
+        stop(msg)
+      }
 
       private$.message(paste("Results available at:", resultsFolder))
     },
@@ -182,6 +287,8 @@ TreatmentPatternsModule <- R6::R6Class(
     #'  \item{cohortName `character(1)`}{Cohort names of the cohorts to be used in the cohort table.}
     #'  \item{type `character(1)` \["target", "event', "exit"\]}{Cohort type, describing if the cohort is a target, event, or exit cohort}
     #' }
+    #' @param description (`character(1)`)
+    #' Description for analysis
     #' @param minEraDuration (`integer(1)`: `0`)\cr
     #' Minimum time an event era should last to be included in analysis
     #' @param splitEventCohorts (`character(n)`: `""`)\cr
@@ -234,7 +341,10 @@ TreatmentPatternsModule <- R6::R6Class(
     #'  \item{`"startDate"`}{Include treatments after the target cohort start date and onwards.}
     #'  \item{`"endDate"`}{Include treatments before target cohort end date and before.}
     #' }
+    #' @param stratify (`logical(1)`)\cr
+    #' This will perform pairwise stratification between age, sex, and index year if set TRUE
     createModuleSpecifications = function(cohorts,
+                                          description = "",
                                           includeTreatments = NULL,
                                           indexDateOffset = NULL,
                                           minEraDuration = 0,
@@ -253,7 +363,8 @@ TreatmentPatternsModule <- R6::R6Class(
                                           startAnchor = "startDate",
                                           windowStart = 0,
                                           endAnchor = "endDate",
-                                          windowEnd = 0) {
+                                          windowEnd = 0,
+                                          stratify = FALSE) {
       if (!is.null(indexDateOffset)) {
         warning("`indexDateOffset` is deprecated in TreatmentPatterns 3.1.0, please use: `startAnchor`, `windowStart`, `endAnchor`, `windowEnd` instead.")
       }
@@ -262,18 +373,208 @@ TreatmentPatternsModule <- R6::R6Class(
         warning("`includeTreatments` is deprecated in TreatentPatterns 3.1.0, please use: `startAnchor`, `windowStart`, `endAnchor`, `windowEnd` instead.")
       }
 
-      analysis <- list()
+      settings <- list()
       for (name in names(formals(self$createModuleSpecifications))) {
         if (name == "cohorts") {
-          analysis[[name]] <- super$.dataFrameToList(get(name))
+          settings[[name]] <- super$.dataFrameToList(get(name))
         } else {
-          analysis[[name]] <- get(name)
+          settings[[name]] <- get(name)
         }
       }
 
-      super$createModuleSpecifications(analysis)
-    },
+      analysis <- list(tpAnalysisList = list(settings))
 
+      specification <- super$createModuleSpecifications(
+        moduleSpecifications = analysis
+      )
+
+      return(specification)
+    },
+    #' @description
+    #' Runs multiple analyses using a list of analysis specification objects (as produced by\code{createAnalysisSpecification}) into a single module specification
+    #'
+    #' @param tpAnalysisList (`list()`)\cr
+    #' A list of analysis specification objects.
+    #' Each element should be a list created by \code{createAnalysisSpecification}
+    #' @examples
+    #' analysis1 <- createAnalysisSpecification(targetCohorts1, eventCohorts1, ...)
+    #' analysis2 <- createAnalysisSpecification(targetCohorts2, eventCohorts2, ...)
+    #' multiSpec <- createMultiAnalysisModuleSpecification(list(spec1, spec2))
+    createMultiAnalysisModuleSpecification = function(tpAnalysisList) {
+      specification <- super$createModuleSpecifications(
+        moduleSpecifications = list(tpAnalysisList = tpAnalysisList)
+      )
+      return(specification)
+    },
+    #' @description
+    #' Creates a settings list describing a TreatmentPatterns analysis. This specification is used by createMultiAnalysisModuleSpecification
+    #'
+    #' @param targetCohorts (`list()`)\cr
+    #' List of target cohorts in list-of-lists form:
+    #' e.g. `list(list(1, "Hypertension"), list(2, "Diabetes"))`.Each inner list must contain `cohortId` (integer) and `cohortName` (string)
+    #' @param eventCohorts (`list()`)\cr
+    #' Same structure as `targetCohorts`. These cohorts are treated as events/treatments
+    #' @param exitCohorts (`list()`)\cr
+    #' Same structure; if provided these are treated as exit cohorts
+    #' @param description (`character(1)`)\cr
+    #' Description for analysis
+    #' @param minEraDuration (`integer(1)`: `0`)\cr
+    #' Minimum time an event era should last to be included in analysis
+    #' @param splitEventCohorts (`character(n)`: `""`)\cr
+    #' Specify event cohort to split in acute (< X days) and therapy (>= X days)
+    #' @param splitTime (`integer(1)`: `30`)\cr
+    #' Specify number of days (X) at which each of the split event cohorts should
+    #' be split in acute and therapy
+    #' @param eraCollapseSize (`integer(1)`: `30`)\cr
+    #' Window of time between which two eras of the same event cohort are collapsed
+    #' into one era
+    #' @param combinationWindow (`integer(1)`: `30`)\cr
+    #' Window of time two event cohorts need to overlap to be considered a
+    #' combination treatment
+    #' @param minPostCombinationDuration (`integer(1)`: `30`)\cr
+    #' Minimum time an event era before or after a generated combination treatment
+    #' should last to be included in analysis
+    #' @param filterTreatments (`character(1)`: `"First"` \["first", "Changes", "all"\])\cr
+    #' Select first occurrence of (‘First’); changes between (‘Changes’); or all
+    #' event cohorts (‘All’).
+    #' @param maxPathLength (`integer(1)`: `5`)\cr
+    #' Maximum number of steps included in treatment pathway
+    #' @param ageWindow (`integer(n)`: `10`)\cr
+    #' Number of years to bin age groups into. It may also be a vector of integers.
+    #' I.e. `c(0, 18, 150)` which will results in age group `0-18` which includes
+    #' subjects `< 19`. And age group `18-150` which includes subjects `> 18`.
+    #' @param minCellCount (`integer(1)`: `5`)\cr
+    #' Minimum count required per pathway. Censors data below `x` as `<x`. This
+    #' minimum value will carry over to the sankey diagram and sunburst plot.
+    #' @param censorType (`character(1)`)\cr
+    #' \describe{
+    #'   \item{`"minCellCount"`}{Censors pathways <`minCellCount` to `minCellCount`.}
+    #'   \item{`"remove"`}{Censors pathways <`minCellCount` by removing them completely.}
+    #'   \item{`"mean"`}{Censors pathways <`minCellCount` to the mean of all frequencies below `minCellCount`}
+    #' }
+    #' @param overlapMethod (`character(1)`: `"truncate"`) Method to decide how to deal
+    #' with overlap that is not significant enough for combination. `"keep"` will
+    #' keep the dates as is. `"truncate"` truncates the first occurring event to
+    #' the start date of the next event.
+    #' @param concatTargets (`logical(1)`: `TRUE`) Should multiple target cohorts for the same person be concatenated or not?
+    #' @param startAnchor (`character(1)`: `"startDate"`) Start date anchor. One of: `"startDate"`, `"endDate"`
+    #' @param windowStart (`numeric(1)`: `0`) Offset for `startAnchor` in days.
+    #' @param endAnchor (`character(1)`: `"endDate"`) End date anchor. One of: `"startDate"`, `"endDate"`
+    #' @param windowEnd (`numeric(1)`: `0`) Offset for `endAnchor` in days.
+    #' @param indexDateOffset (`integer(1)`: `0`)\cr
+    #' `DEPRECATED`
+    #' Offset the index date of the `Target` cohort.
+    #' @param includeTreatments (`character(1)`: `"startDate"`)\cr
+    #' `DEPRECATED`
+    #' \describe{
+    #'  \item{`"startDate"`}{Include treatments after the target cohort start date and onwards.}
+    #'  \item{`"endDate"`}{Include treatments before target cohort end date and before.}
+    #' }
+    #' @param stratify (`logical(1)`)\cr
+    #' This will perform pairwise stratification between age, sex, and index year if set TRUE
+    #'
+    #' @details
+    #' - cohortName must not contain `-` or `+`. Cohort names are validated as
+    #'   (perl-compatible) regular expressions. If invalid, an informative error is
+    #'   raised.
+    #'
+    #' @return A `list` describing analysis settings. Keys include:
+    #'  - `cohorts`: list of cohort definitions (each item has `cohortId`,
+    #'     `cohortName`, `type`)
+    #'  - all parameters passed to this function (same names)
+    createAnalysisSpecification = function(targetCohorts,
+                                           eventCohorts,
+                                           exitCohorts = list(),
+                                           description = "",
+                                           includeTreatments = NULL,
+                                           indexDateOffset = NULL,
+                                           minEraDuration = 0,
+                                           splitEventCohorts = NULL,
+                                           splitTime = NULL,
+                                           eraCollapseSize = 30,
+                                           combinationWindow = 30,
+                                           minPostCombinationDuration = 30,
+                                           filterTreatments = "First",
+                                           maxPathLength = 5,
+                                           ageWindow = 5,
+                                           minCellCount = 1,
+                                           censorType = "minCellCount",
+                                           overlapMethod = "truncate",
+                                           concatTargets = TRUE,
+                                           startAnchor = "startDate",
+                                           windowStart = 0,
+                                           endAnchor = "endDate",
+                                           windowEnd = 0,
+                                           stratify = FALSE) {
+      if (!is.null(indexDateOffset)) {
+        warning("`indexDateOffset` is deprecated in TreatmentPatterns 3.1.0, please use: `startAnchor`, `windowStart`, `endAnchor`, `windowEnd` instead.")
+      }
+
+      if (!is.null(includeTreatments)) {
+        warning("`includeTreatments` is deprecated in TreatentPatterns 3.1.0, please use: `startAnchor`, `windowStart`, `endAnchor`, `windowEnd` instead.")
+      }
+
+      if (is.null(targetCohorts) | is.null(eventCohorts)) {
+        stop(sprintf("targetCohorts or eventCohorts are empty"))
+      }
+
+      # validate target names
+      for (cohort in c(targetCohorts, eventCohorts, exitCohorts)) {
+        pattern <- cohort[[2]]
+        tryCatch(
+          {
+            # Attempt to compile the regex by running grepl on an empty string
+            grepl(pattern, "", perl = TRUE)
+            if (grepl("[-+]", pattern, perl = TRUE)) {
+              stop(sprintf("Invalid target cohort name; remove -/+"))
+            }
+          },
+          error = function(e) {
+            stop(
+              sprintf(
+                "Invalid target cohort name '%s': %s",
+                pattern, e$message
+              ),
+              call. = FALSE
+            )
+          }
+        )
+      }
+
+      targetCohorts <- as.data.frame(do.call(rbind, targetCohorts), stringsAsFactors = FALSE) %>% dplyr::mutate(type = "target")
+
+      eventCohorts <- as.data.frame(do.call(rbind, eventCohorts), stringsAsFactors = FALSE) %>% dplyr::mutate(type = "event")
+
+      exitCohorts <- if (length(exitCohorts) > 0) {
+        exitCohorts <- as.data.frame(do.call(rbind, exitCohorts), stringsAsFactors = FALSE) %>% dplyr::mutate(type = "exit")
+      }
+
+
+      if (!is.null(exitCohorts) && nrow(exitCohorts) > 0) {
+        cohorts <- dplyr::bind_rows(targetCohorts, eventCohorts, exitCohorts)
+      } else {
+        cohorts <- dplyr::bind_rows(targetCohorts, eventCohorts)
+      }
+
+      colnames(cohorts) <- c("cohortId", "cohortName", "type")
+
+      cohorts$cohortId <- as.integer(cohorts$cohortId)
+      cohorts$cohortName <- as.character(cohorts$cohortName)
+      cohorts$type <- as.character(cohorts$type)
+
+      cohorts <- super$.dataFrameToList(cohorts)
+
+      settings <- list()
+      settings[["cohorts"]] <- cohorts
+
+      params <- names(formals(self$createAnalysisSpecification))
+      paramsToUse <- params[-seq_len(3)]
+      for (name in paramsToUse) {
+        settings[[name]] <- get(name)
+      }
+
+      return(settings)
+    },
     #' @description Validate the module specifications
     #'
     #' @param moduleSpecifications The CohortMethod module specifications

--- a/inst/csv/treatmentPatternsRdms.csv
+++ b/inst/csv/treatmentPatternsRdms.csv
@@ -3,9 +3,9 @@ analyses,analysis_id,int,Yes,Yes,Analysis identifier
 analyses,description,varchar,Yes,No,Analysis description
 arguments,analysis_id,int,Yes,Yes,Analysis identifier
 arguments,arguments,varchar,No,No,Arguments as JSON
-arguments,database_id,varchar,Yes,No,Unique identifier for the database
+arguments,database_id,varchar,Yes,Yes,Unique identifier for the database
 attrition,analysis_id,int,Yes,Yes,Analysis identifier foreign key
-attrition,database_id,varchar,Yes,No,Unique identifier for the database
+attrition,database_id,varchar,Yes,Yes,Unique identifier for the database
 attrition,number_records,int,Yes,No,Number of records
 attrition,number_subjects,int,Yes,No,Number of subjects
 attrition,reason,varchar,Yes,Yes,Reason description
@@ -28,18 +28,18 @@ cdm_source_info,source_release_date,date,Yes,No,Source release date
 cdm_source_info,vocabulary_version,varchar,Yes,No,Vocabulary version
 counts_age,age,int,Yes,Yes,Age in years
 counts_age,analysis_id,int,Yes,Yes,Analysis identifier foreign key
-counts_age,database_id,varchar,Yes,No,Unique identifier for the database
+counts_age,database_id,varchar,Yes,Yes,Unique identifier for the database
 counts_age,n,varchar,Yes,No,Count per age. May be <x
 counts_age,target_cohort_id,int,No,Yes,Target cohort ID
 counts_age,target_cohort_name,varchar,No,No,Target cohort name
 counts_sex,analysis_id,int,Yes,Yes,Analysis identifier foreign key
-counts_sex,database_id,varchar,Yes,No,Unique identifier for the database
+counts_sex,database_id,varchar,Yes,Yes,Unique identifier for the database
 counts_sex,n,varchar,Yes,No,Count per sex. May be <x
 counts_sex,sex,varchar,Yes,Yes,Sex group
 counts_sex,target_cohort_id,int,No,Yes,Target cohort ID
 counts_sex,target_cohort_name,varchar,No,No,Target cohort name
 counts_year,analysis_id,int,Yes,Yes,Analysis identifier foreign key
-counts_year,database_id,varchar,Yes,No,Unique identifier for the database
+counts_year,database_id,varchar,Yes,Yes,Unique identifier for the database
 counts_year,n,varchar,Yes,No,Count per year. May be <x
 counts_year,target_cohort_id,int,No,Yes,Target cohort ID
 counts_year,target_cohort_name,varchar,No,No,Target cohort name
@@ -54,7 +54,7 @@ metadata,r_version,varchar,Yes,No,R version
 summary_event_duration,analysis_id,int,Yes,Yes,Analysis identifier foreign key
 summary_event_duration,duration_average,float,Yes,No,Average duration in days
 summary_event_duration,event_count,int,Yes,No,Count of (combination) event
-summary_event_duration,database_id,varchar,Yes,No,Unique identifier for the database
+summary_event_duration,database_id,varchar,Yes,Yes,Unique identifier for the database
 summary_event_duration,event_name,varchar,Yes,Yes,Name of (combination) event
 summary_event_duration,line,varchar,Yes,Yes,Position in pathway. I.e. 1 equals the first event in a pathway. 2 the second etc. Overall indicates across the entire pathway
 summary_event_duration,duration_max,int,Yes,No,Maximum duration in days
@@ -65,17 +65,17 @@ summary_event_duration,duration_q_2,int,Yes,No,Q2 duration in days
 summary_event_duration,duration_sd,float,Yes,No,Standard Deviation of duration in days
 summary_event_duration,target_cohort_id,int,No,Yes,Target cohort ID
 summary_event_duration,target_cohort_name,varchar,No,No,Target cohort name
-treatment_pathways,age,varchar,Yes,No,Age stratum
+treatment_pathways,age,varchar,Yes,Yes,Age stratum
 treatment_pathways,analysis_id,int,Yes,Yes,Analysis identifier foreign key
-treatment_pathways,database_id,varchar,Yes,No,Unique identifier for the database
+treatment_pathways,database_id,varchar,Yes,Yes,Unique identifier for the database
 treatment_pathways,freq,int,Yes,No,Count of pathway
-treatment_pathways,index_year,varchar,Yes,No,Target index year stratum
+treatment_pathways,index_year,varchar,Yes,Yes,Target index year stratum
 treatment_pathways,pathway,varchar,Yes,Yes,Pathway
-treatment_pathways,sex,varchar,Yes,No,Sex stratum
+treatment_pathways,sex,varchar,Yes,Yes,Sex stratum
 treatment_pathways,target_cohort_id,int,No,Yes,Target cohort ID
 treatment_pathways,target_cohort_name,varchar,No,No,Target cohort name
-analysis_cohorts,target_cohort_name,varchar,No,No,Target cohort name
-analysis_cohorts,target_cohort_id,int,Yes,Yes,Target cohort Id
-analysis_cohorts,event_cohort_name,varchar,No,No,Event cohort name
-analysis_cohorts,event_cohort_id,int,Yes,Yes,Event cohort Id
-analysis_cohorts,analysis_id,int,Yes,Yes,Analysis identifier foreign key
+analysis_cohorts,cohort_id,varchar,No,Yes,Cohort id
+analysis_cohorts,cohort_name,int,Yes,No,Cohort name
+analysis_cohorts,type,varchar,No,Yes,"Cohort type (target, event, exit)"
+analysis_cohorts,analysis_id,int,Yes,Yes,Analysis Id
+,,,,,

--- a/inst/csv/treatmentPatternsRdms.csv
+++ b/inst/csv/treatmentPatternsRdms.csv
@@ -74,7 +74,7 @@ treatment_pathways,sex,varchar,yes,no,Sex stratum
 treatment_pathways,target_cohort_id,integer,FALSE,FALSE,Target cohort ID
 treatment_pathways,target_cohort_name,varchar,FALSE,FALSE,Target cohort name
 analysis_cohorts,target_cohort_name,varchar,no,no,Target cohort name
-analysis_cohorts,target_cohort_id,int,no,yes,Target cohort Id
+analysis_cohorts,target_cohort_id,int,yes,yes,Target cohort Id
 analysis_cohorts,event_cohort_name,varchar,no,no,Event cohort name
-analysis_cohorts,event_cohort_id,int,no,yes,Event cohort Id
+analysis_cohorts,event_cohort_id,int,yes,yes,Event cohort Id
 analysis_cohorts,analysis_id,int,yes,yes,Analysis identifier foreign key

--- a/inst/csv/treatmentPatternsRdms.csv
+++ b/inst/csv/treatmentPatternsRdms.csv
@@ -78,4 +78,3 @@ analysis_cohorts,cohort_id,varchar,No,Yes,Cohort id
 analysis_cohorts,cohort_name,int,Yes,No,Cohort name
 analysis_cohorts,type,varchar,No,Yes,"Cohort type (target, event, exit)"
 analysis_cohorts,analysis_id,int,Yes,Yes,Analysis Id
-,,,,,

--- a/inst/csv/treatmentPatternsRdms.csv
+++ b/inst/csv/treatmentPatternsRdms.csv
@@ -73,3 +73,8 @@ treatment_pathways,pathway,varchar,yes,no,Pathway
 treatment_pathways,sex,varchar,yes,no,Sex stratum
 treatment_pathways,target_cohort_id,integer,FALSE,FALSE,Target cohort ID
 treatment_pathways,target_cohort_name,varchar,FALSE,FALSE,Target cohort name
+analysis_cohorts,target_cohort_name,varchar,no,no,Target cohort name
+analysis_cohorts,target_cohort_id,int,no,yes,Target cohort Id
+analysis_cohorts,event_cohort_name,varchar,no,no,Event cohort name
+analysis_cohorts,event_cohort_id,int,no,yes,Event cohort Id
+analysis_cohorts,analysis_id,int,yes,yes,Analysis identifier foreign key

--- a/inst/csv/treatmentPatternsRdms.csv
+++ b/inst/csv/treatmentPatternsRdms.csv
@@ -73,6 +73,7 @@ treatment_pathways,index_year,varchar,Yes,No,Target index year stratum
 treatment_pathways,pathway,varchar,Yes,No,Pathway
 treatment_pathways,sex,varchar,Yes,No,Sex stratum
 treatment_pathways,target_cohort_id,int,No,No,Target cohort ID
+treatment_pathways,target_cohort_name,varchar,No,No,Target cohort name
 analysis_cohorts,target_cohort_name,varchar,No,No,Target cohort name
 analysis_cohorts,target_cohort_id,int,Yes,Yes,Target cohort Id
 analysis_cohorts,event_cohort_name,varchar,No,No,Event cohort name

--- a/inst/csv/treatmentPatternsRdms.csv
+++ b/inst/csv/treatmentPatternsRdms.csv
@@ -73,8 +73,8 @@ treatment_pathways,pathway,varchar,yes,no,Pathway
 treatment_pathways,sex,varchar,yes,no,Sex stratum
 treatment_pathways,target_cohort_id,integer,FALSE,FALSE,Target cohort ID
 treatment_pathways,target_cohort_name,varchar,FALSE,FALSE,Target cohort name
-analysis_cohorts,target_cohort_name,varchar,no,no,Target cohort name
-analysis_cohorts,target_cohort_id,int,yes,yes,Target cohort Id
-analysis_cohorts,event_cohort_name,varchar,no,no,Event cohort name
-analysis_cohorts,event_cohort_id,int,yes,yes,Event cohort Id
-analysis_cohorts,analysis_id,int,yes,yes,Analysis identifier foreign key
+analysis_cohorts,target_cohort_name,varchar,No,No,Target cohort name
+analysis_cohorts,target_cohort_id,int,Yes,Yes,Target cohort Id
+analysis_cohorts,event_cohort_name,varchar,No,No,Event cohort name
+analysis_cohorts,event_cohort_id,int,Yes,Yes,Event cohort Id
+analysis_cohorts,analysis_id,int,Yes,Yes,Analysis identifier foreign key

--- a/inst/csv/treatmentPatternsRdms.csv
+++ b/inst/csv/treatmentPatternsRdms.csv
@@ -56,7 +56,7 @@ summary_event_duration,duration_average,float,Yes,No,Average duration in days
 summary_event_duration,event_count,int,Yes,No,Count of (combination) event
 summary_event_duration,database_id,varchar,Yes,No,Unique identifier for the database
 summary_event_duration,event_name,varchar,Yes,Yes,Name of (combination) event
-summary_event_duration,line,varchar,Yes,No,Position in pathway. I.e. 1 equals the first event in a pathway. 2 the second etc. Overall indicates across the entire pathway
+summary_event_duration,line,varchar,Yes,Yes,Position in pathway. I.e. 1 equals the first event in a pathway. 2 the second etc. Overall indicates across the entire pathway
 summary_event_duration,duration_max,int,Yes,No,Maximum duration in days
 summary_event_duration,duration_median,int,Yes,No,Median duration in days
 summary_event_duration,duration_min,int,Yes,No,Minimum duration in days

--- a/inst/csv/treatmentPatternsRdms.csv
+++ b/inst/csv/treatmentPatternsRdms.csv
@@ -1,4 +1,83 @@
 table_name,column_name,data_type,is_required,primary_key,description
+analyses,analysis_id,int,yes,no,Analysis identifier
+analyses,description,varchar,yes,no,Analysis description
+arguments,analysis_id,int,yes,no,Analysis identifier
+arguments,arguments,varchar,no,no,Arguments as JSON
+arguments,database_id,integer,TRUE,TRUE,Unique identifier for the database
+attrition,analysis_id,int,yes,no,Analysis identifier foreign key
+attrition,database_id,integer,TRUE,TRUE,Unique identifier for the database
+attrition,number_records,int,yes,no,Number of records
+attrition,number_subjects,int,yes,no,Number of subjects
+attrition,reason,varchar,yes,no,Reason description
+attrition,reason_id,int,yes,no,Reason Identifier
+attrition,target_cohort_id,integer,FALSE,FALSE,Target cohort ID
+attrition,target_cohort_name,varchar,FALSE,FALSE,Target cohort name
+attrition,time_stamp,bigint,yes,no,Time stamp in seconds since epoch (1970-01-01)
+cdm_source_info,analysis_id,int,yes,no,Analysis identifier foreign key
+cdm_source_info,cdm_etl_reference,varchar,yes,no,CDM ETL Reference
+cdm_source_info,cdm_holder,varchar,yes,no,Cdm holder
+cdm_source_info,cdm_release_date,date,yes,no,CDM release date
+cdm_source_info,cdm_source_abbreviation,varchar,yes,no,CDM Source Abbreviation
+cdm_source_info,cdm_source_name,varchar,yes,no,CDM Source Name
+cdm_source_info,cdm_version,varchar,yes,no,CDM version
+cdm_source_info,database_id,integer,TRUE,TRUE,Unique identifier for the database
+cdm_source_info,source_description,varchar,yes,no,Source description
+cdm_source_info,source_documentation_reference,varchar,yes,no,Source Documentation Reference
+cdm_source_info,source_release_date,date,yes,no,Source release date
+cdm_source_info,vocabulary_version,varchar,yes,no,Vocabulary version
+counts_age,age,int,yes,no,Age in years
+counts_age,analysis_id,int,yes,no,Analysis identifier foreign key
+counts_age,database_id,integer,TRUE,TRUE,Unique identifier for the database
+counts_age,n,varchar,yes,no,Count per age. May be <x
+counts_age,target_cohort_id,integer,FALSE,FALSE,Target cohort ID
+counts_age,target_cohort_name,varchar,FALSE,FALSE,Target cohort name
+counts_sex,analysis_id,int,yes,no,Analysis identifier foreign key
+counts_sex,database_id,integer,TRUE,TRUE,Unique identifier for the database
+counts_sex,n,varchar,yes,no,Count per sex. May be <x
+counts_sex,sex,varchar,yes,no,Sex group
+counts_sex,target_cohort_id,integer,FALSE,FALSE,Target cohort ID
+counts_sex,target_cohort_name,varchar,FALSE,FALSE,Target cohort name
+counts_year,analysis_id,int,yes,no,Analysis identifier foreign key
+counts_year,database_id,integer,TRUE,TRUE,Unique identifier for the database
+counts_year,n,varchar,yes,no,Count per year. May be <x
+counts_year,target_cohort_id,integer,FALSE,FALSE,Target cohort ID
+counts_year,target_cohort_name,varchar,FALSE,FALSE,Target cohort name
+counts_year,index_year,integer,FALSE,FALSE,Calendar year
+metadata,analysis_id,int,yes,no,Analysis identifier foreign key
+metadata,database_id,integer,TRUE,TRUE,Unique identifier for the database
+metadata,execution_end,bigint,yes,no,Time stamp in seconds since epoch (1970-01-01)
+metadata,execution_start,bigint,yes,no,Time stamp in seconds since epoch (1970-01-01)
+metadata,package_version,varchar,yes,no,TreatmentPatterns version
+metadata,platform,varchar,yes,no,Platform (Example: x86_64-w64-mingw32)
+metadata,r_version,varchar,yes,no,R version
+summary_event_duration,analysis_id,int,yes,no,Analysis identifier foreign key
+summary_event_duration,duration_average,float,yes,no,Average duration in days
+summary_event_duration,event_count,int,yes,no,Count of (combination) event
+summary_event_duration,database_id,integer,TRUE,TRUE,Unique identifier for the database
+summary_event_duration,event_name,varchar,yes,no,Name of (combination) event
+summary_event_duration,line,varchar,yes,no,Position in pathway. I.e. 1 equals the first event in a pathway. 2 the second etc. Overall indicates across the entire pathway
+summary_event_duration,duration_max,int,yes,no,Maximum duration in days
+summary_event_duration,duration_median,int,yes,no,Median duration in days
+summary_event_duration,duration_min,int,yes,no,Minimum duration in days
+summary_event_duration,duration_q_1,int,yes,no,Q1 duration in days
+summary_event_duration,duration_q_2,int,yes,no,Q2 duration in days
+summary_event_duration,duration_sd,float,yes,no,Standard Deviation of duration in days
+summary_event_duration,target_cohort_id,integer,FALSE,FALSE,Target cohort ID
+summary_event_duration,target_cohort_name,varchar,FALSE,FALSE,Target cohort name
+treatment_pathways,age,varchar,yes,no,Age stratum
+treatment_pathways,analysis_id,int,yes,no,Analysis identifier foreign key
+treatment_pathways,database_id,integer,TRUE,TRUE,Unique identifier for the database
+treatment_pathways,freq,int,yes,no,Count of pathway
+treatment_pathways,index_year,varchar,yes,no,Target index year stratum
+treatment_pathways,pathway,varchar,yes,no,Pathway
+treatment_pathways,sex,varchar,yes,no,Sex stratum
+treatment_pathways,target_cohort_id,integer,FALSE,FALSE,Target cohort ID
+treatment_pathways,target_cohort_name,varchar,FALSE,FALSE,Target cohort name
+analysis_cohorts,target_cohort_name,varchar,No,No,Target cohort name
+analysis_cohorts,target_cohort_id,int,Yes,Yes,Target cohort Id
+analysis_cohorts,event_cohort_name,varchar,No,No,Event cohort name
+analysis_cohorts,event_cohort_id,int,Yes,Yes,Event cohort Id
+analysis_cohorts,analysis_id,int,Yes,Yes,Analysis identifier foreign key
 analyses,analysis_id,int,Yes,No,Analysis identifier
 analyses,description,varchar,Yes,No,Analysis description
 arguments,analysis_id,int,Yes,No,Analysis identifier

--- a/inst/csv/treatmentPatternsRdms.csv
+++ b/inst/csv/treatmentPatternsRdms.csv
@@ -1,80 +1,76 @@
 table_name,column_name,data_type,is_required,primary_key,description
-analyses,analysis_id,int,yes,no,Analysis identifier
-analyses,description,varchar,yes,no,Analysis description
-arguments,analysis_id,int,yes,no,Analysis identifier
-arguments,arguments,varchar,no,no,Arguments as JSON
-arguments,database_id,integer,TRUE,TRUE,Unique identifier for the database
-attrition,analysis_id,int,yes,no,Analysis identifier foreign key
-attrition,database_id,integer,TRUE,TRUE,Unique identifier for the database
-attrition,number_records,int,yes,no,Number of records
-attrition,number_subjects,int,yes,no,Number of subjects
-attrition,reason,varchar,yes,no,Reason description
-attrition,reason_id,int,yes,no,Reason Identifier
-attrition,target_cohort_id,integer,FALSE,FALSE,Target cohort ID
-attrition,target_cohort_name,varchar,FALSE,FALSE,Target cohort name
-attrition,time_stamp,bigint,yes,no,Time stamp in seconds since epoch (1970-01-01)
-cdm_source_info,analysis_id,int,yes,no,Analysis identifier foreign key
-cdm_source_info,cdm_etl_reference,varchar,yes,no,CDM ETL Reference
-cdm_source_info,cdm_holder,varchar,yes,no,Cdm holder
-cdm_source_info,cdm_release_date,date,yes,no,CDM release date
-cdm_source_info,cdm_source_abbreviation,varchar,yes,no,CDM Source Abbreviation
-cdm_source_info,cdm_source_name,varchar,yes,no,CDM Source Name
-cdm_source_info,cdm_version,varchar,yes,no,CDM version
-cdm_source_info,database_id,integer,TRUE,TRUE,Unique identifier for the database
-cdm_source_info,source_description,varchar,yes,no,Source description
-cdm_source_info,source_documentation_reference,varchar,yes,no,Source Documentation Reference
-cdm_source_info,source_release_date,date,yes,no,Source release date
-cdm_source_info,vocabulary_version,varchar,yes,no,Vocabulary version
-counts_age,age,int,yes,no,Age in years
-counts_age,analysis_id,int,yes,no,Analysis identifier foreign key
-counts_age,database_id,integer,TRUE,TRUE,Unique identifier for the database
-counts_age,n,varchar,yes,no,Count per age. May be <x
-counts_age,target_cohort_id,integer,FALSE,FALSE,Target cohort ID
-counts_age,target_cohort_name,varchar,FALSE,FALSE,Target cohort name
-counts_sex,analysis_id,int,yes,no,Analysis identifier foreign key
-counts_sex,database_id,integer,TRUE,TRUE,Unique identifier for the database
-counts_sex,n,varchar,yes,no,Count per sex. May be <x
-counts_sex,sex,varchar,yes,no,Sex group
-counts_sex,target_cohort_id,integer,FALSE,FALSE,Target cohort ID
-counts_sex,target_cohort_name,varchar,FALSE,FALSE,Target cohort name
-counts_year,analysis_id,int,yes,no,Analysis identifier foreign key
-counts_year,database_id,integer,TRUE,TRUE,Unique identifier for the database
-counts_year,n,varchar,yes,no,Count per year. May be <x
-counts_year,target_cohort_id,integer,FALSE,FALSE,Target cohort ID
-counts_year,target_cohort_name,varchar,FALSE,FALSE,Target cohort name
-counts_year,index_year,integer,FALSE,FALSE,Calendar year
-metadata,analysis_id,int,yes,no,Analysis identifier foreign key
-metadata,database_id,integer,TRUE,TRUE,Unique identifier for the database
-metadata,execution_end,bigint,yes,no,Time stamp in seconds since epoch (1970-01-01)
-metadata,execution_start,bigint,yes,no,Time stamp in seconds since epoch (1970-01-01)
-metadata,package_version,varchar,yes,no,TreatmentPatterns version
-metadata,platform,varchar,yes,no,Platform (Example: x86_64-w64-mingw32)
-metadata,r_version,varchar,yes,no,R version
-summary_event_duration,analysis_id,int,yes,no,Analysis identifier foreign key
-summary_event_duration,duration_average,float,yes,no,Average duration in days
-summary_event_duration,event_count,int,yes,no,Count of (combination) event
-summary_event_duration,database_id,integer,TRUE,TRUE,Unique identifier for the database
-summary_event_duration,event_name,varchar,yes,no,Name of (combination) event
-summary_event_duration,line,varchar,yes,no,Position in pathway. I.e. 1 equals the first event in a pathway. 2 the second etc. Overall indicates across the entire pathway
-summary_event_duration,duration_max,int,yes,no,Maximum duration in days
-summary_event_duration,duration_median,int,yes,no,Median duration in days
-summary_event_duration,duration_min,int,yes,no,Minimum duration in days
-summary_event_duration,duration_q_1,int,yes,no,Q1 duration in days
-summary_event_duration,duration_q_2,int,yes,no,Q2 duration in days
-summary_event_duration,duration_sd,float,yes,no,Standard Deviation of duration in days
-summary_event_duration,target_cohort_id,integer,FALSE,FALSE,Target cohort ID
-summary_event_duration,target_cohort_name,varchar,FALSE,FALSE,Target cohort name
-treatment_pathways,age,varchar,yes,no,Age stratum
-treatment_pathways,analysis_id,int,yes,no,Analysis identifier foreign key
-treatment_pathways,database_id,integer,TRUE,TRUE,Unique identifier for the database
-treatment_pathways,freq,int,yes,no,Count of pathway
-treatment_pathways,index_year,varchar,yes,no,Target index year stratum
-treatment_pathways,pathway,varchar,yes,no,Pathway
-treatment_pathways,sex,varchar,yes,no,Sex stratum
-treatment_pathways,target_cohort_id,integer,FALSE,FALSE,Target cohort ID
-treatment_pathways,target_cohort_name,varchar,FALSE,FALSE,Target cohort name
-analysis_cohorts,target_cohort_name,varchar,No,No,Target cohort name
-analysis_cohorts,target_cohort_id,int,Yes,Yes,Target cohort Id
-analysis_cohorts,event_cohort_name,varchar,No,No,Event cohort name
-analysis_cohorts,event_cohort_id,int,Yes,Yes,Event cohort Id
-analysis_cohorts,analysis_id,int,Yes,Yes,Analysis identifier foreign key
+analyses,analysis_id,int,Yes,No,Analysis identifier
+analyses,description,varchar,Yes,No,Analysis description
+arguments,analysis_id,int,Yes,No,Analysis identifier
+arguments,arguments,varchar,No,No,Arguments as JSON
+arguments,database_id,varchar,Yes,Yes,Unique identifier for the database
+attrition,analysis_id,int,Yes,No,Analysis identifier foreign key
+attrition,database_id,varchar,Yes,Yes,Unique identifier for the database
+attrition,number_records,int,Yes,No,Number of records
+attrition,number_subjects,int,Yes,No,Number of subjects
+attrition,reason,varchar,Yes,No,Reason description
+attrition,reason_id,int,Yes,No,Reason Identifier
+attrition,target_cohort_id,int,No,No,Target cohort ID
+attrition,target_cohort_name,varchar,No,No,Target cohort name
+attrition,time_stamp,bigint,Yes,No,Time stamp in seconds since epoch (1970-01-01)
+cdm_source_info,analysis_id,int,Yes,No,Analysis identifier foreign key
+cdm_source_info,cdm_etl_reference,varchar,Yes,No,CDM ETL Reference
+cdm_source_info,cdm_holder,varchar,Yes,No,Cdm holder
+cdm_source_info,cdm_release_date,date,Yes,No,CDM release date
+cdm_source_info,cdm_source_abbreviation,varchar,Yes,No,CDM Source Abbreviation
+cdm_source_info,cdm_source_name,varchar,Yes,No,CDM Source Name
+cdm_source_info,cdm_version,varchar,Yes,No,CDM version
+cdm_source_info,cdm_version_concept_id,int,No,No,The Concept Id representing the version of the CDM.
+cdm_source_info,database_id,varchar,Yes,Yes,Unique identifier for the database
+cdm_source_info,source_description,varchar,Yes,No,Source description
+cdm_source_info,source_documentation_reference,varchar,Yes,No,Source Documentation Reference
+cdm_source_info,source_release_date,date,Yes,No,Source release date
+cdm_source_info,vocabulary_version,varchar,Yes,No,Vocabulary version
+counts_age,age,int,Yes,No,Age in years
+counts_age,analysis_id,int,Yes,No,Analysis identifier foreign key
+counts_age,database_id,varchar,Yes,Yes,Unique identifier for the database
+counts_age,n,varchar,Yes,No,Count per age. May be <x
+counts_age,target_cohort_id,int,No,No,Target cohort ID
+counts_age,target_cohort_name,varchar,No,No,Target cohort name
+counts_sex,analysis_id,int,Yes,No,Analysis identifier foreign key
+counts_sex,database_id,varchar,Yes,Yes,Unique identifier for the database
+counts_sex,n,varchar,Yes,No,Count per sex. May be <x
+counts_sex,sex,varchar,Yes,No,Sex group
+counts_sex,target_cohort_id,int,No,No,Target cohort ID
+counts_sex,target_cohort_name,varchar,No,No,Target cohort name
+counts_year,analysis_id,int,Yes,No,Analysis identifier foreign key
+counts_year,database_id,varchar,Yes,Yes,Unique identifier for the database
+counts_year,n,varchar,Yes,No,Count per year. May be <x
+counts_year,target_cohort_id,int,No,No,Target cohort ID
+counts_year,target_cohort_name,varchar,No,No,Target cohort name
+counts_year,index_year,int,No,No,Calendar year
+metadata,analysis_id,int,Yes,No,Analysis identifier foreign key
+metadata,database_id,varchar,Yes,Yes,Unique identifier for the database
+metadata,execution_end,bigint,Yes,No,Time stamp in seconds since epoch (1970-01-01)
+metadata,execution_start,bigint,Yes,No,Time stamp in seconds since epoch (1970-01-01)
+metadata,package_version,varchar,Yes,No,TreatmentPatterns version
+metadata,platform,varchar,Yes,No,Platform (Example: x86_64-w64-mingw32)
+metadata,r_version,varchar,Yes,No,R version
+summary_event_duration,analysis_id,int,Yes,No,Analysis identifier foreign key
+summary_event_duration,duration_average,float,Yes,No,Average duration in days
+summary_event_duration,event_count,int,Yes,No,Count of (combination) event
+summary_event_duration,database_id,varchar,Yes,Yes,Unique identifier for the database
+summary_event_duration,event_name,varchar,Yes,No,Name of (combination) event
+summary_event_duration,line,varchar,Yes,No,Position in pathway. I.e. 1 equals the first event in a pathway. 2 the second etc. Overall indicates across the entire pathway
+summary_event_duration,duration_max,int,Yes,No,Maximum duration in days
+summary_event_duration,duration_median,int,Yes,No,Median duration in days
+summary_event_duration,duration_min,int,Yes,No,Minimum duration in days
+summary_event_duration,duration_q_1,int,Yes,No,Q1 duration in days
+summary_event_duration,duration_q_2,int,Yes,No,Q2 duration in days
+summary_event_duration,duration_sd,float,Yes,No,Standard Deviation of duration in days
+summary_event_duration,target_cohort_id,int,No,No,Target cohort ID
+summary_event_duration,target_cohort_name,varchar,No,No,Target cohort name
+treatment_pathways,age,varchar,Yes,No,Age stratum
+treatment_pathways,analysis_id,int,Yes,No,Analysis identifier foreign key
+treatment_pathways,database_id,varchar,Yes,Yes,Unique identifier for the database
+treatment_pathways,freq,int,Yes,No,Count of pathway
+treatment_pathways,index_year,varchar,Yes,No,Target index year stratum
+treatment_pathways,pathway,varchar,Yes,No,Pathway
+treatment_pathways,sex,varchar,Yes,No,Sex stratum
+treatment_pathways,target_cohort_id,int,No,No,Target cohort ID
+treatment_pathways,target_cohort_name,varchar,No,No,Target cohort name

--- a/inst/csv/treatmentPatternsRdms.csv
+++ b/inst/csv/treatmentPatternsRdms.csv
@@ -1,19 +1,19 @@
 table_name,column_name,data_type,is_required,primary_key,description
-analyses,analysis_id,int,Yes,No,Analysis identifier
+analyses,analysis_id,int,Yes,Yes,Analysis identifier
 analyses,description,varchar,Yes,No,Analysis description
-arguments,analysis_id,int,Yes,No,Analysis identifier
+arguments,analysis_id,int,Yes,Yes,Analysis identifier
 arguments,arguments,varchar,No,No,Arguments as JSON
-arguments,database_id,varchar,Yes,Yes,Unique identifier for the database
-attrition,analysis_id,int,Yes,No,Analysis identifier foreign key
-attrition,database_id,varchar,Yes,Yes,Unique identifier for the database
+arguments,database_id,varchar,Yes,No,Unique identifier for the database
+attrition,analysis_id,int,Yes,Yes,Analysis identifier foreign key
+attrition,database_id,varchar,Yes,No,Unique identifier for the database
 attrition,number_records,int,Yes,No,Number of records
 attrition,number_subjects,int,Yes,No,Number of subjects
-attrition,reason,varchar,Yes,No,Reason description
+attrition,reason,varchar,Yes,Yes,Reason description
 attrition,reason_id,int,Yes,No,Reason Identifier
-attrition,target_cohort_id,int,No,No,Target cohort ID
+attrition,target_cohort_id,int,No,Yes,Target cohort ID
 attrition,target_cohort_name,varchar,No,No,Target cohort name
 attrition,time_stamp,bigint,Yes,No,Time stamp in seconds since epoch (1970-01-01)
-cdm_source_info,analysis_id,int,Yes,No,Analysis identifier foreign key
+cdm_source_info,analysis_id,int,Yes,Yes,Analysis identifier foreign key
 cdm_source_info,cdm_etl_reference,varchar,Yes,No,CDM ETL Reference
 cdm_source_info,cdm_holder,varchar,Yes,No,Cdm holder
 cdm_source_info,cdm_release_date,date,Yes,No,CDM release date
@@ -26,36 +26,36 @@ cdm_source_info,source_description,varchar,Yes,No,Source description
 cdm_source_info,source_documentation_reference,varchar,Yes,No,Source Documentation Reference
 cdm_source_info,source_release_date,date,Yes,No,Source release date
 cdm_source_info,vocabulary_version,varchar,Yes,No,Vocabulary version
-counts_age,age,int,Yes,No,Age in years
-counts_age,analysis_id,int,Yes,No,Analysis identifier foreign key
-counts_age,database_id,varchar,Yes,Yes,Unique identifier for the database
+counts_age,age,int,Yes,Yes,Age in years
+counts_age,analysis_id,int,Yes,Yes,Analysis identifier foreign key
+counts_age,database_id,varchar,Yes,No,Unique identifier for the database
 counts_age,n,varchar,Yes,No,Count per age. May be <x
-counts_age,target_cohort_id,int,No,No,Target cohort ID
+counts_age,target_cohort_id,int,No,Yes,Target cohort ID
 counts_age,target_cohort_name,varchar,No,No,Target cohort name
-counts_sex,analysis_id,int,Yes,No,Analysis identifier foreign key
-counts_sex,database_id,varchar,Yes,Yes,Unique identifier for the database
+counts_sex,analysis_id,int,Yes,Yes,Analysis identifier foreign key
+counts_sex,database_id,varchar,Yes,No,Unique identifier for the database
 counts_sex,n,varchar,Yes,No,Count per sex. May be <x
-counts_sex,sex,varchar,Yes,No,Sex group
-counts_sex,target_cohort_id,int,No,No,Target cohort ID
+counts_sex,sex,varchar,Yes,Yes,Sex group
+counts_sex,target_cohort_id,int,No,Yes,Target cohort ID
 counts_sex,target_cohort_name,varchar,No,No,Target cohort name
-counts_year,analysis_id,int,Yes,No,Analysis identifier foreign key
-counts_year,database_id,varchar,Yes,Yes,Unique identifier for the database
+counts_year,analysis_id,int,Yes,Yes,Analysis identifier foreign key
+counts_year,database_id,varchar,Yes,No,Unique identifier for the database
 counts_year,n,varchar,Yes,No,Count per year. May be <x
-counts_year,target_cohort_id,int,No,No,Target cohort ID
+counts_year,target_cohort_id,int,No,Yes,Target cohort ID
 counts_year,target_cohort_name,varchar,No,No,Target cohort name
-counts_year,index_year,int,No,No,Calendar year
-metadata,analysis_id,int,Yes,No,Analysis identifier foreign key
+counts_year,index_year,int,No,Yes,Calendar year
+metadata,analysis_id,int,Yes,Yes,Analysis identifier foreign key
 metadata,database_id,varchar,Yes,Yes,Unique identifier for the database
 metadata,execution_end,bigint,Yes,No,Time stamp in seconds since epoch (1970-01-01)
 metadata,execution_start,bigint,Yes,No,Time stamp in seconds since epoch (1970-01-01)
 metadata,package_version,varchar,Yes,No,TreatmentPatterns version
 metadata,platform,varchar,Yes,No,Platform (Example: x86_64-w64-mingw32)
 metadata,r_version,varchar,Yes,No,R version
-summary_event_duration,analysis_id,int,Yes,No,Analysis identifier foreign key
+summary_event_duration,analysis_id,int,Yes,Yes,Analysis identifier foreign key
 summary_event_duration,duration_average,float,Yes,No,Average duration in days
 summary_event_duration,event_count,int,Yes,No,Count of (combination) event
-summary_event_duration,database_id,varchar,Yes,Yes,Unique identifier for the database
-summary_event_duration,event_name,varchar,Yes,No,Name of (combination) event
+summary_event_duration,database_id,varchar,Yes,No,Unique identifier for the database
+summary_event_duration,event_name,varchar,Yes,Yes,Name of (combination) event
 summary_event_duration,line,varchar,Yes,No,Position in pathway. I.e. 1 equals the first event in a pathway. 2 the second etc. Overall indicates across the entire pathway
 summary_event_duration,duration_max,int,Yes,No,Maximum duration in days
 summary_event_duration,duration_median,int,Yes,No,Median duration in days
@@ -63,16 +63,16 @@ summary_event_duration,duration_min,int,Yes,No,Minimum duration in days
 summary_event_duration,duration_q_1,int,Yes,No,Q1 duration in days
 summary_event_duration,duration_q_2,int,Yes,No,Q2 duration in days
 summary_event_duration,duration_sd,float,Yes,No,Standard Deviation of duration in days
-summary_event_duration,target_cohort_id,int,No,No,Target cohort ID
+summary_event_duration,target_cohort_id,int,No,Yes,Target cohort ID
 summary_event_duration,target_cohort_name,varchar,No,No,Target cohort name
 treatment_pathways,age,varchar,Yes,No,Age stratum
-treatment_pathways,analysis_id,int,Yes,No,Analysis identifier foreign key
-treatment_pathways,database_id,varchar,Yes,Yes,Unique identifier for the database
+treatment_pathways,analysis_id,int,Yes,Yes,Analysis identifier foreign key
+treatment_pathways,database_id,varchar,Yes,No,Unique identifier for the database
 treatment_pathways,freq,int,Yes,No,Count of pathway
 treatment_pathways,index_year,varchar,Yes,No,Target index year stratum
-treatment_pathways,pathway,varchar,Yes,No,Pathway
+treatment_pathways,pathway,varchar,Yes,Yes,Pathway
 treatment_pathways,sex,varchar,Yes,No,Sex stratum
-treatment_pathways,target_cohort_id,int,No,No,Target cohort ID
+treatment_pathways,target_cohort_id,int,No,Yes,Target cohort ID
 treatment_pathways,target_cohort_name,varchar,No,No,Target cohort name
 analysis_cohorts,target_cohort_name,varchar,No,No,Target cohort name
 analysis_cohorts,target_cohort_id,int,Yes,Yes,Target cohort Id

--- a/inst/csv/treatmentPatternsRdms.csv
+++ b/inst/csv/treatmentPatternsRdms.csv
@@ -74,7 +74,7 @@ treatment_pathways,pathway,varchar,Yes,Yes,Pathway
 treatment_pathways,sex,varchar,Yes,Yes,Sex stratum
 treatment_pathways,target_cohort_id,int,No,Yes,Target cohort ID
 treatment_pathways,target_cohort_name,varchar,No,No,Target cohort name
-analysis_cohorts,cohort_id,varchar,No,Yes,Cohort id
-analysis_cohorts,cohort_name,int,Yes,No,Cohort name
+analysis_cohorts,cohort_id,int,No,Yes,Cohort id
+analysis_cohorts,cohort_name,varchar,Yes,No,Cohort name
 analysis_cohorts,type,varchar,No,Yes,"Cohort type (target, event, exit)"
 analysis_cohorts,analysis_id,int,Yes,Yes,Analysis Id

--- a/inst/testdata/cdmModulesAnalysisSpecifications.json
+++ b/inst/testdata/cdmModulesAnalysisSpecifications.json
@@ -484,160 +484,181 @@
       "settings": {
         "tpAnalysisList": [
           {
-            "cohorts": [
-              {
-                "cohortId": 11,
-                "cohortName": "ViralSinusitis",
-                "type": "target"
-              },
-              {
-                "cohortId": 1,
-                "cohortName": "Celecoxib",
-                "type": "event"
-              },
-              {
-                "cohortId": 2,
-                "cohortName": "Diclofenac",
-                "type": "event"
-              },
-              {
-                "cohortId": 3,
-                "cohortName": "GI bleed",
-                "type": "event"
-              },
-              {
-                "cohortId": 4,
-                "cohortName": "Acetaminophen",
-                "type": "event"
-              },
-              {
-                "cohortId": 5,
-                "cohortName": "Amoxicillin",
-                "type": "event"
-              },
-              {
-                "cohortId": 6,
-                "cohortName": "Aspirin",
-                "type": "event"
-              },
-              {
-                "cohortId": 7,
-                "cohortName": "Clavulanate",
-                "type": "event"
-              },
-              {
-                "cohortId": 9,
-                "cohortName": "Doxylamine",
-                "type": "event"
-              },
-              {
-                "cohortId": 10,
-                "cohortName": "PenicillinV",
-                "type": "event"
-              },
-              {
-                "cohortId": 1001,
-                "cohortName": "Celecoxib: age 18 to 64 Age 18 to 64",
-                "type": "event"
-              },
-              {
-                "cohortId": 2001,
-                "cohortName": "Diclofenac: age 18 to 64 Age 18 to 64",
-                "type": "event"
-              },
-              {
-                "cohortId": 1002,
-                "cohortName": "Celecoxib: first event with 365 prior obs first event with 365 prior obs",
-                "type": "event"
-              },
-              {
-                "cohortId": 2002,
-                "cohortName": "Diclofenac: first event with 365 prior obs first event with 365 prior obs",
-                "type": "event"
-              },
-              {
-                "cohortId": 1003,
-                "cohortName": "Celecoxib: age 18 to 64 and first event with 365 prior obs Age 18 to 64, first event with 365 prior obs",
-                "type": "event"
-              },
-              {
-                "cohortId": 2003,
-                "cohortName": "Diclofenac: age 18 to 64 and first event with 365 prior obs Age 18 to 64, first event with 365 prior obs",
-                "type": "event"
-              },
-              {
-                "cohortId": 8,
-                "cohortName": "death",
-                "type": "exit"
-              }
-            ],
-            "analysisId": 1,
-            "description": "Analysis 1",
-            "minEraDuration": 7,
-            "eraCollapseSize": 14,
-            "combinationWindow": 7,
-            "minPostCombinationDuration": 7,
-            "filterTreatments": "First",
-            "maxPathLength": 5,
-            "ageWindow": 5,
-            "minCellCount": 1,
-            "censorType": "minCellCount",
-            "overlapMethod": "truncate",
-            "concatTargets": true,
-            "startAnchor": "startDate",
-            "windowStart": 0,
-            "endAnchor": "endDate",
-            "windowEnd": 0,
-            "stratify": false
+            "module": "TreatmentPatternsModule",
+            "settings": {
+              "cohorts": [
+                {
+                  "cohortId": 11,
+                  "cohortName": "ViralSinusitis",
+                  "type": "target"
+                },
+                {
+                  "cohortId": 1,
+                  "cohortName": "Celecoxib",
+                  "type": "event"
+                },
+                {
+                  "cohortId": 2,
+                  "cohortName": "Diclofenac",
+                  "type": "event"
+                },
+                {
+                  "cohortId": 3,
+                  "cohortName": "GI bleed",
+                  "type": "event"
+                },
+                {
+                  "cohortId": 4,
+                  "cohortName": "Acetaminophen",
+                  "type": "event"
+                },
+                {
+                  "cohortId": 5,
+                  "cohortName": "Amoxicillin",
+                  "type": "event"
+                },
+                {
+                  "cohortId": 6,
+                  "cohortName": "Aspirin",
+                  "type": "event"
+                },
+                {
+                  "cohortId": 7,
+                  "cohortName": "Clavulanate",
+                  "type": "event"
+                },
+                {
+                  "cohortId": 9,
+                  "cohortName": "Doxylamine",
+                  "type": "event"
+                },
+                {
+                  "cohortId": 10,
+                  "cohortName": "PenicillinV",
+                  "type": "event"
+                },
+                {
+                  "cohortId": 1001,
+                  "cohortName": "Celecoxib: age 18 to 64 Age 18 to 64",
+                  "type": "event"
+                },
+                {
+                  "cohortId": 2001,
+                  "cohortName": "Diclofenac: age 18 to 64 Age 18 to 64",
+                  "type": "event"
+                },
+                {
+                  "cohortId": 2002,
+                  "cohortName": "Diclofenac: first event with 365 prior obs first event with 365 prior obs",
+                  "type": "event"
+                },
+                {
+                  "cohortId": 1003,
+                  "cohortName": "Celecoxib: age 18 to 64 and first event with 365 prior obs Age 18 to 64, first event with 365 prior obs",
+                  "type": "event"
+                },
+                {
+                  "cohortId": 2003,
+                  "cohortName": "Diclofenac: age 18 to 64 and first event with 365 prior obs Age 18 to 64, first event with 365 prior obs",
+                  "type": "event"
+                },
+                {
+                  "cohortId": 8,
+                  "cohortName": "death",
+                  "type": "exit"
+                }
+              ],
+              "analysisId": 1,
+              "description": "Analysis 1",
+              "minEraDuration": 7,
+              "eraCollapseSize": 14,
+              "combinationWindow": 7,
+              "minPostCombinationDuration": 7,
+              "filterTreatments": "First",
+              "maxPathLength": 5,
+              "ageWindow": 5,
+              "minCellCount": 1,
+              "censorType": "minCellCount",
+              "overlapMethod": "truncate",
+              "concatTargets": true,
+              "startAnchor": "startDate",
+              "windowStart": 0,
+              "endAnchor": "endDate",
+              "windowEnd": 0,
+              "stratify": false
+            },
+            "attr_class": ["ModuleSpecifications", "TreatmentPatternsModuleSpecifications"]
           },
           {
-            "cohorts": [
-              {
-                "cohortId": 11,
-                "cohortName": "ViralSinusitis",
-                "type": "target"
-              },
-              {
-                "cohortId": 1,
-                "cohortName": "Celecoxib",
-                "type": "event"
-              },
-              {
-                "cohortId": 2,
-                "cohortName": "Diclofenac",
-                "type": "event"
-              },
-              {
-                "cohortId": 3,
-                "cohortName": "GI bleed",
-                "type": "event"
-              },
-              {
-                "cohortId": 4,
-                "cohortName": "Acetaminophen",
-                "type": "event"
-              }
-            ],
-            "analysisId": 2,
-            "description": "Analysis 2",
-            "includeTreatments": "startDate",
-            "indexDateOffset": 0,
-            "minEraDuration": 7,
-            "eraCollapseSize": 14,
-            "combinationWindow": 7,
-            "minPostCombinationDuration": 7,
-            "filterTreatments": "First",
-            "maxPathLength": 5,
-            "ageWindow": 5,
-            "minCellCount": 1,
-            "censorType": "minCellCount",
-            "overlapMethod": "truncate",
-            "concatTargets": true,
-            "startAnchor": "startDate",
-            "windowStart": 0,
-            "endAnchor": "endDate",
-            "windowEnd": 0,
-            "stratify": false
+            "module": "TreatmentPatternsModule",
+            "settings": {
+              "cohorts": [
+                {
+                  "cohortId": 11,
+                  "cohortName": "ViralSinusitis",
+                  "type": "target"
+                },
+                {
+                  "cohortId": 1,
+                  "cohortName": "Celecoxib",
+                  "type": "event"
+                },
+                {
+                  "cohortId": 2,
+                  "cohortName": "Diclofenac",
+                  "type": "event"
+                },
+                {
+                  "cohortId": 3,
+                  "cohortName": "GI bleed",
+                  "type": "event"
+                },
+                {
+                  "cohortId": 4,
+                  "cohortName": "Acetaminophen",
+                  "type": "event"
+                },
+                {
+                  "cohortId": 5,
+                  "cohortName": "Amoxicillin",
+                  "type": "event"
+                },
+                {
+                  "cohortId": 6,
+                  "cohortName": "Aspirin",
+                  "type": "event"
+                },
+                {
+                  "cohortId": 7,
+                  "cohortName": "Clavulanate",
+                  "type": "event"
+                },
+                {
+                  "cohortId": 8,
+                  "cohortName": "death",
+                  "type": "exit"
+                }
+              ],
+              "analysisId": 2,
+              "description": "Analysis 1",
+              "minEraDuration": 7,
+              "eraCollapseSize": 14,
+              "combinationWindow": 7,
+              "minPostCombinationDuration": 7,
+              "filterTreatments": "First",
+              "maxPathLength": 5,
+              "ageWindow": 5,
+              "minCellCount": 1,
+              "censorType": "minCellCount",
+              "overlapMethod": "truncate",
+              "concatTargets": true,
+              "startAnchor": "startDate",
+              "windowStart": 0,
+              "endAnchor": "endDate",
+              "windowEnd": 0,
+              "stratify": true
+            },
+            "attr_class": ["ModuleSpecifications", "TreatmentPatternsModuleSpecifications"]
           }
         ]
       },

--- a/inst/testdata/cdmModulesAnalysisSpecifications.json
+++ b/inst/testdata/cdmModulesAnalysisSpecifications.json
@@ -482,108 +482,164 @@
     {
       "module": "TreatmentPatternsModule",
       "settings": {
-        "cohorts": [
+        "tpAnalysisList": [
           {
-            "cohortId": 11,
-            "cohortName": "ViralSinusitis",
-            "type": "target"
+            "cohorts": [
+              {
+                "cohortId": 11,
+                "cohortName": "ViralSinusitis",
+                "type": "target"
+              },
+              {
+                "cohortId": 1,
+                "cohortName": "Celecoxib",
+                "type": "event"
+              },
+              {
+                "cohortId": 2,
+                "cohortName": "Diclofenac",
+                "type": "event"
+              },
+              {
+                "cohortId": 3,
+                "cohortName": "GI bleed",
+                "type": "event"
+              },
+              {
+                "cohortId": 4,
+                "cohortName": "Acetaminophen",
+                "type": "event"
+              },
+              {
+                "cohortId": 5,
+                "cohortName": "Amoxicillin",
+                "type": "event"
+              },
+              {
+                "cohortId": 6,
+                "cohortName": "Aspirin",
+                "type": "event"
+              },
+              {
+                "cohortId": 7,
+                "cohortName": "Clavulanate",
+                "type": "event"
+              },
+              {
+                "cohortId": 9,
+                "cohortName": "Doxylamine",
+                "type": "event"
+              },
+              {
+                "cohortId": 10,
+                "cohortName": "PenicillinV",
+                "type": "event"
+              },
+              {
+                "cohortId": 1001,
+                "cohortName": "Celecoxib: age 18 to 64 Age 18 to 64",
+                "type": "event"
+              },
+              {
+                "cohortId": 2001,
+                "cohortName": "Diclofenac: age 18 to 64 Age 18 to 64",
+                "type": "event"
+              },
+              {
+                "cohortId": 1002,
+                "cohortName": "Celecoxib: first event with 365 prior obs first event with 365 prior obs",
+                "type": "event"
+              },
+              {
+                "cohortId": 2002,
+                "cohortName": "Diclofenac: first event with 365 prior obs first event with 365 prior obs",
+                "type": "event"
+              },
+              {
+                "cohortId": 1003,
+                "cohortName": "Celecoxib: age 18 to 64 and first event with 365 prior obs Age 18 to 64, first event with 365 prior obs",
+                "type": "event"
+              },
+              {
+                "cohortId": 2003,
+                "cohortName": "Diclofenac: age 18 to 64 and first event with 365 prior obs Age 18 to 64, first event with 365 prior obs",
+                "type": "event"
+              },
+              {
+                "cohortId": 8,
+                "cohortName": "death",
+                "type": "exit"
+              }
+            ],
+            "analysisId": 1,
+            "description": "Analysis 1",
+            "minEraDuration": 7,
+            "eraCollapseSize": 14,
+            "combinationWindow": 7,
+            "minPostCombinationDuration": 7,
+            "filterTreatments": "First",
+            "maxPathLength": 5,
+            "ageWindow": 5,
+            "minCellCount": 1,
+            "censorType": "minCellCount",
+            "overlapMethod": "truncate",
+            "concatTargets": true,
+            "startAnchor": "startDate",
+            "windowStart": 0,
+            "endAnchor": "endDate",
+            "windowEnd": 0,
+            "stratify": false
           },
           {
-            "cohortId": 1,
-            "cohortName": "Celecoxib",
-            "type": "event"
-          },
-          {
-            "cohortId": 2,
-            "cohortName": "Diclofenac",
-            "type": "event"
-          },
-          {
-            "cohortId": 3,
-            "cohortName": "GI bleed",
-            "type": "event"
-          },
-          {
-            "cohortId": 4,
-            "cohortName": "Acetaminophen",
-            "type": "event"
-          },
-          {
-            "cohortId": 5,
-            "cohortName": "Amoxicillin",
-            "type": "event"
-          },
-          {
-            "cohortId": 6,
-            "cohortName": "Aspirin",
-            "type": "event"
-          },
-          {
-            "cohortId": 7,
-            "cohortName": "Clavulanate",
-            "type": "event"
-          },
-          {
-            "cohortId": 9,
-            "cohortName": "Doxylamine",
-            "type": "event"
-          },
-          {
-            "cohortId": 10,
-            "cohortName": "PenicillinV",
-            "type": "event"
-          },
-          {
-            "cohortId": 1001,
-            "cohortName": "Celecoxib - age 18 to 64 Age 18 to 64",
-            "type": "event"
-          },
-          {
-            "cohortId": 2001,
-            "cohortName": "Diclofenac - age 18 to 64 Age 18 to 64",
-            "type": "event"
-          },
-          {
-            "cohortId": 1002,
-            "cohortName": "Celecoxib - first event with 365 prior obs first event with 365 prior obs",
-            "type": "event"
-          },
-          {
-            "cohortId": 2002,
-            "cohortName": "Diclofenac - first event with 365 prior obs first event with 365 prior obs",
-            "type": "event"
-          },
-          {
-            "cohortId": 1003,
-            "cohortName": "Celecoxib - age 18 to 64 and first event with 365 prior obs Age 18 to 64, first event with 365 prior obs",
-            "type": "event"
-          },
-          {
-            "cohortId": 2003,
-            "cohortName": "Diclofenac - age 18 to 64 and first event with 365 prior obs Age 18 to 64, first event with 365 prior obs",
-            "type": "event"
-          },
-          {
-            "cohortId": 8,
-            "cohortName": "Death",
-            "type": "exit"
+            "cohorts": [
+              {
+                "cohortId": 11,
+                "cohortName": "ViralSinusitis",
+                "type": "target"
+              },
+              {
+                "cohortId": 1,
+                "cohortName": "Celecoxib",
+                "type": "event"
+              },
+              {
+                "cohortId": 2,
+                "cohortName": "Diclofenac",
+                "type": "event"
+              },
+              {
+                "cohortId": 3,
+                "cohortName": "GI bleed",
+                "type": "event"
+              },
+              {
+                "cohortId": 4,
+                "cohortName": "Acetaminophen",
+                "type": "event"
+              }
+            ],
+            "analysisId": 2,
+            "description": "Analysis 2",
+            "includeTreatments": "startDate",
+            "indexDateOffset": 0,
+            "minEraDuration": 7,
+            "eraCollapseSize": 14,
+            "combinationWindow": 7,
+            "minPostCombinationDuration": 7,
+            "filterTreatments": "First",
+            "maxPathLength": 5,
+            "ageWindow": 5,
+            "minCellCount": 1,
+            "censorType": "minCellCount",
+            "overlapMethod": "truncate",
+            "concatTargets": true,
+            "startAnchor": "startDate",
+            "windowStart": 0,
+            "endAnchor": "endDate",
+            "windowEnd": 0,
+            "stratify": false
           }
-        ],
-        "minEraDuration": 7,
-        "eraCollapseSize": 14,
-        "combinationWindow": 7,
-        "minPostCombinationDuration": 7,
-        "filterTreatments": "First",
-        "maxPathLength": 5,
-        "ageWindow": 5,
-        "minCellCount": 1,
-        "censorType": "minCellCount",
-        "overlapMethod": "truncate",
-        "concatTargets": true,
-        "startAnchor": "startDate",
-        "windowStart": 0,
-        "endAnchor": "endDate",
-        "windowEnd": 0
+        ]
       },
       "attr_class": ["ModuleSpecifications", "TreatmentPatternsModuleSpecifications"]
     },

--- a/man/TreatmentPatternsModule.Rd
+++ b/man/TreatmentPatternsModule.Rd
@@ -26,7 +26,6 @@ Characterization and description of patterns of events (cohorts). against the OM
 \item \href{#method-TreatmentPatternsModule-uploadResults}{\code{TreatmentPatternsModule$uploadResults()}}
 \item \href{#method-TreatmentPatternsModule-createModuleSpecifications}{\code{TreatmentPatternsModule$createModuleSpecifications()}}
 \item \href{#method-TreatmentPatternsModule-createMultiAnalysisModuleSpecification}{\code{TreatmentPatternsModule$createMultiAnalysisModuleSpecification()}}
-\item \href{#method-TreatmentPatternsModule-createAnalysisSpecification}{\code{TreatmentPatternsModule$createAnalysisSpecification()}}
 \item \href{#method-TreatmentPatternsModule-validateModuleSpecifications}{\code{TreatmentPatternsModule$validateModuleSpecifications()}}
 \item \href{#method-TreatmentPatternsModule-clone}{\code{TreatmentPatternsModule$clone()}}
 }
@@ -175,7 +174,10 @@ Creates the TreatmentPatternsnModule Specifications
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{TreatmentPatternsModule$createModuleSpecifications(
   analysisId = 1,
-  cohorts,
+  cohorts = NULL,
+  targetCohorts = NULL,
+  eventCohorts = NULL,
+  exitCohorts = NULL,
   description = "",
   includeTreatments = NULL,
   indexDateOffset = NULL,
@@ -213,6 +215,16 @@ Data frame containing the following columns and data types:
 \item{cohortName \code{character(1)}}{Cohort names of the cohorts to be used in the cohort table.}
 \item{type \code{character(1)} ["target", "event', "exit"]}{Cohort type, describing if the cohort is a target, event, or exit cohort}
 }}
+
+\item{\code{targetCohorts}}{(\code{list()})\cr
+List of target cohorts in list-of-lists form:
+e.g. \code{list(list(1, "Hypertension"), list(2, "Diabetes"))}.Each inner list must contain \code{cohortId} (integer) and \code{cohortName} (string)}
+
+\item{\code{eventCohorts}}{(\code{list()})\cr
+Same structure as \code{targetCohorts}. These cohorts are treated as events/treatments}
+
+\item{\code{exitCohorts}}{(\code{list()})\cr
+Same structure; if provided these are treated as exit cohorts}
 
 \item{\code{description}}{(\code{character(1)})
 Description for analysis}
@@ -298,7 +310,7 @@ This will perform pairwise stratification between age, sex, and index year if se
 \if{html}{\out{<a id="method-TreatmentPatternsModule-createMultiAnalysisModuleSpecification"></a>}}
 \if{latex}{\out{\hypertarget{method-TreatmentPatternsModule-createMultiAnalysisModuleSpecification}{}}}
 \subsection{Method \code{createMultiAnalysisModuleSpecification()}}{
-Runs multiple analyses using a list of analysis specification objects (as produced by\code{createAnalysisSpecification}) into a single module specification
+Runs multiple analyses using a list of analysis specification objects (as produced by\code{createModuleSpecifications}) into a single module specification
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{TreatmentPatternsModule$createMultiAnalysisModuleSpecification(tpAnalysisList)}\if{html}{\out{</div>}}
 }
@@ -311,153 +323,6 @@ A list of analysis specification objects.
 Each element should be a list created by \code{createAnalysisSpecification}}
 }
 \if{html}{\out{</div>}}
-}
-}
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-TreatmentPatternsModule-createAnalysisSpecification"></a>}}
-\if{latex}{\out{\hypertarget{method-TreatmentPatternsModule-createAnalysisSpecification}{}}}
-\subsection{Method \code{createAnalysisSpecification()}}{
-Creates a settings list describing a TreatmentPatterns analysis. This specification is used by createMultiAnalysisModuleSpecification
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{TreatmentPatternsModule$createAnalysisSpecification(
-  analysisId,
-  targetCohorts,
-  eventCohorts,
-  exitCohorts = list(),
-  description = "",
-  includeTreatments = NULL,
-  indexDateOffset = NULL,
-  minEraDuration = 0,
-  splitEventCohorts = NULL,
-  splitTime = NULL,
-  eraCollapseSize = 30,
-  combinationWindow = 30,
-  minPostCombinationDuration = 30,
-  filterTreatments = "First",
-  maxPathLength = 5,
-  ageWindow = 5,
-  minCellCount = 1,
-  censorType = "minCellCount",
-  overlapMethod = "truncate",
-  concatTargets = TRUE,
-  startAnchor = "startDate",
-  windowStart = 0,
-  endAnchor = "endDate",
-  windowEnd = 0,
-  stratify = FALSE
-)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{analysisId}}{(\code{numeric(1)})
-Unique identifier for the TreatmentPatterns analysis}
-
-\item{\code{targetCohorts}}{(\code{list()})\cr
-List of target cohorts in list-of-lists form:
-e.g. \code{list(list(1, "Hypertension"), list(2, "Diabetes"))}.Each inner list must contain \code{cohortId} (integer) and \code{cohortName} (string)}
-
-\item{\code{eventCohorts}}{(\code{list()})\cr
-Same structure as \code{targetCohorts}. These cohorts are treated as events/treatments}
-
-\item{\code{exitCohorts}}{(\code{list()})\cr
-Same structure; if provided these are treated as exit cohorts}
-
-\item{\code{description}}{(\code{character(1)})\cr
-Description for analysis}
-
-\item{\code{includeTreatments}}{(\code{character(1)}: \code{"startDate"})\cr
-\code{DEPRECATED}
-\describe{
-\item{\code{"startDate"}}{Include treatments after the target cohort start date and onwards.}
-\item{\code{"endDate"}}{Include treatments before target cohort end date and before.}
-}}
-
-\item{\code{indexDateOffset}}{(\code{integer(1)}: \code{0})\cr
-\code{DEPRECATED}
-Offset the index date of the \code{Target} cohort.}
-
-\item{\code{minEraDuration}}{(\code{integer(1)}: \code{0})\cr
-Minimum time an event era should last to be included in analysis}
-
-\item{\code{splitEventCohorts}}{(\code{character(n)}: \code{""})\cr
-Specify event cohort to split in acute (< X days) and therapy (>= X days)}
-
-\item{\code{splitTime}}{(\code{integer(1)}: \code{30})\cr
-Specify number of days (X) at which each of the split event cohorts should
-be split in acute and therapy}
-
-\item{\code{eraCollapseSize}}{(\code{integer(1)}: \code{30})\cr
-Window of time between which two eras of the same event cohort are collapsed
-into one era}
-
-\item{\code{combinationWindow}}{(\code{integer(1)}: \code{30})\cr
-Window of time two event cohorts need to overlap to be considered a
-combination treatment}
-
-\item{\code{minPostCombinationDuration}}{(\code{integer(1)}: \code{30})\cr
-Minimum time an event era before or after a generated combination treatment
-should last to be included in analysis}
-
-\item{\code{filterTreatments}}{(\code{character(1)}: \code{"First"} ["first", "Changes", "all"])\cr
-Select first occurrence of (‘First’); changes between (‘Changes’); or all
-event cohorts (‘All’).}
-
-\item{\code{maxPathLength}}{(\code{integer(1)}: \code{5})\cr
-Maximum number of steps included in treatment pathway}
-
-\item{\code{ageWindow}}{(\code{integer(n)}: \code{10})\cr
-Number of years to bin age groups into. It may also be a vector of integers.
-I.e. \code{c(0, 18, 150)} which will results in age group \code{0-18} which includes
-subjects \verb{< 19}. And age group \code{18-150} which includes subjects \verb{> 18}.}
-
-\item{\code{minCellCount}}{(\code{integer(1)}: \code{5})\cr
-Minimum count required per pathway. Censors data below \code{x} as \verb{<x}. This
-minimum value will carry over to the sankey diagram and sunburst plot.}
-
-\item{\code{censorType}}{(\code{character(1)})\cr
-\describe{
-\item{\code{"minCellCount"}}{Censors pathways <\code{minCellCount} to \code{minCellCount}.}
-\item{\code{"remove"}}{Censors pathways <\code{minCellCount} by removing them completely.}
-\item{\code{"mean"}}{Censors pathways <\code{minCellCount} to the mean of all frequencies below \code{minCellCount}}
-}}
-
-\item{\code{overlapMethod}}{(\code{character(1)}: \code{"truncate"}) Method to decide how to deal
-with overlap that is not significant enough for combination. \code{"keep"} will
-keep the dates as is. \code{"truncate"} truncates the first occurring event to
-the start date of the next event.}
-
-\item{\code{concatTargets}}{(\code{logical(1)}: \code{TRUE}) Should multiple target cohorts for the same person be concatenated or not?}
-
-\item{\code{startAnchor}}{(\code{character(1)}: \code{"startDate"}) Start date anchor. One of: \code{"startDate"}, \code{"endDate"}}
-
-\item{\code{windowStart}}{(\code{numeric(1)}: \code{0}) Offset for \code{startAnchor} in days.}
-
-\item{\code{endAnchor}}{(\code{character(1)}: \code{"endDate"}) End date anchor. One of: \code{"startDate"}, \code{"endDate"}}
-
-\item{\code{windowEnd}}{(\code{numeric(1)}: \code{0}) Offset for \code{endAnchor} in days.}
-
-\item{\code{stratify}}{(\code{logical(1)})\cr
-This will perform pairwise stratification between age, sex, and index year if set TRUE}
-}
-\if{html}{\out{</div>}}
-}
-\subsection{Details}{
-\itemize{
-\item cohortName must not contain \code{-} or \code{+}. Cohort names are validated as
-(perl-compatible) regular expressions. If invalid, an informative error is
-raised.
-}
-}
-
-\subsection{Returns}{
-A \code{list} describing analysis settings. Keys include:
-\itemize{
-\item \code{cohorts}: list of cohort definitions (each item has \code{cohortId},
-\code{cohortName}, \code{type})
-\item all parameters passed to this function (same names)
-}
 }
 }
 \if{html}{\out{<hr>}}

--- a/man/TreatmentPatternsModule.Rd
+++ b/man/TreatmentPatternsModule.Rd
@@ -12,8 +12,8 @@ Characterization and description of patterns of events (cohorts). against the OM
 ## Method `TreatmentPatternsModule$createMultiAnalysisModuleSpecification`
 ## ------------------------------------------------
 
-analysis1 <- createAnalysisSpecification(targetCohorts1, eventCohorts1, ...)
-analysis2 <- createAnalysisSpecification(targetCohorts2, eventCohorts2, ...)
+analysis1 <- createAnalysisSpecification(analysisId1, targetCohorts1, eventCohorts1, ...)
+analysis2 <- createAnalysisSpecification(analysisId2, targetCohorts2, eventCohorts2, ...)
 multiSpec <- createMultiAnalysisModuleSpecification(list(spec1, spec2))
 }
 \section{Super class}{
@@ -184,6 +184,7 @@ by \code{\link[=createEmptyAnalysisSpecificiations]{createEmptyAnalysisSpecifici
 Creates the TreatmentPatternsnModule Specifications
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{TreatmentPatternsModule$createModuleSpecifications(
+  analysisId = 1,
   cohorts,
   description = "",
   includeTreatments = NULL,
@@ -212,6 +213,9 @@ Creates the TreatmentPatternsnModule Specifications
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
+\item{\code{analysisId}}{(\code{numeric(1)})
+Unique identifier for the TreatmentPatterns analysis}
+
 \item{\code{cohorts}}{(\code{data.frame()})\cr
 Data frame containing the following columns and data types:
 \describe{
@@ -336,6 +340,7 @@ multiSpec <- createMultiAnalysisModuleSpecification(list(spec1, spec2))
 Creates a settings list describing a TreatmentPatterns analysis. This specification is used by createMultiAnalysisModuleSpecification
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{TreatmentPatternsModule$createAnalysisSpecification(
+  analysisId,
   targetCohorts,
   eventCohorts,
   exitCohorts = list(),
@@ -366,6 +371,9 @@ Creates a settings list describing a TreatmentPatterns analysis. This specificat
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
+\item{\code{analysisId}}{(\code{numeric(1)})
+Unique identifier for the TreatmentPatterns analysis}
+
 \item{\code{targetCohorts}}{(\code{list()})\cr
 List of target cohorts in list-of-lists form:
 e.g. \code{list(list(1, "Hypertension"), list(2, "Diabetes"))}.Each inner list must contain \code{cohortId} (integer) and \code{cohortName} (string)}
@@ -484,7 +492,7 @@ Validate the module specifications
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{moduleSpecifications}}{The CohortMethod module specifications}
+\item{\code{moduleSpecifications}}{The treatment patterns module specifications}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/TreatmentPatternsModule.Rd
+++ b/man/TreatmentPatternsModule.Rd
@@ -6,6 +6,16 @@
 \description{
 Characterization and description of patterns of events (cohorts). against the OMOP Common Data Model.
 }
+\examples{
+
+## ------------------------------------------------
+## Method `TreatmentPatternsModule$createMultiAnalysisModuleSpecification`
+## ------------------------------------------------
+
+analysis1 <- createAnalysisSpecification(targetCohorts1, eventCohorts1, ...)
+analysis2 <- createAnalysisSpecification(targetCohorts2, eventCohorts2, ...)
+multiSpec <- createMultiAnalysisModuleSpecification(list(spec1, spec2))
+}
 \section{Super class}{
 \code{\link[Strategus:StrategusModule]{Strategus::StrategusModule}} -> \code{TreatmentPatternsModule}
 }
@@ -25,6 +35,8 @@ Characterization and description of patterns of events (cohorts). against the OM
 \item \href{#method-TreatmentPatternsModule-getResultsDataModelSpecification}{\code{TreatmentPatternsModule$getResultsDataModelSpecification()}}
 \item \href{#method-TreatmentPatternsModule-uploadResults}{\code{TreatmentPatternsModule$uploadResults()}}
 \item \href{#method-TreatmentPatternsModule-createModuleSpecifications}{\code{TreatmentPatternsModule$createModuleSpecifications()}}
+\item \href{#method-TreatmentPatternsModule-createMultiAnalysisModuleSpecification}{\code{TreatmentPatternsModule$createMultiAnalysisModuleSpecification()}}
+\item \href{#method-TreatmentPatternsModule-createAnalysisSpecification}{\code{TreatmentPatternsModule$createAnalysisSpecification()}}
 \item \href{#method-TreatmentPatternsModule-validateModuleSpecifications}{\code{TreatmentPatternsModule$validateModuleSpecifications()}}
 \item \href{#method-TreatmentPatternsModule-clone}{\code{TreatmentPatternsModule$clone()}}
 }
@@ -173,6 +185,7 @@ Creates the TreatmentPatternsnModule Specifications
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{TreatmentPatternsModule$createModuleSpecifications(
   cohorts,
+  description = "",
   includeTreatments = NULL,
   indexDateOffset = NULL,
   minEraDuration = 0,
@@ -191,7 +204,8 @@ Creates the TreatmentPatternsnModule Specifications
   startAnchor = "startDate",
   windowStart = 0,
   endAnchor = "endDate",
-  windowEnd = 0
+  windowEnd = 0,
+  stratify = FALSE
 )}\if{html}{\out{</div>}}
 }
 
@@ -205,6 +219,9 @@ Data frame containing the following columns and data types:
 \item{cohortName \code{character(1)}}{Cohort names of the cohorts to be used in the cohort table.}
 \item{type \code{character(1)} ["target", "event', "exit"]}{Cohort type, describing if the cohort is a target, event, or exit cohort}
 }}
+
+\item{\code{description}}{(\code{character(1)})
+Description for analysis}
 
 \item{\code{includeTreatments}}{(\code{character(1)}: \code{"startDate"})\cr
 \code{DEPRECATED}
@@ -276,8 +293,183 @@ the start date of the next event.}
 \item{\code{endAnchor}}{(\code{character(1)}: \code{"endDate"}) End date anchor. One of: \code{"startDate"}, \code{"endDate"}}
 
 \item{\code{windowEnd}}{(\code{numeric(1)}: \code{0}) Offset for \code{endAnchor} in days.}
+
+\item{\code{stratify}}{(\code{logical(1)})\cr
+This will perform pairwise stratification between age, sex, and index year if set TRUE}
 }
 \if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-TreatmentPatternsModule-createMultiAnalysisModuleSpecification"></a>}}
+\if{latex}{\out{\hypertarget{method-TreatmentPatternsModule-createMultiAnalysisModuleSpecification}{}}}
+\subsection{Method \code{createMultiAnalysisModuleSpecification()}}{
+Runs multiple analyses using a list of analysis specification objects (as produced by\code{createAnalysisSpecification}) into a single module specification
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{TreatmentPatternsModule$createMultiAnalysisModuleSpecification(tpAnalysisList)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{tpAnalysisList}}{(\code{list()})\cr
+A list of analysis specification objects.
+Each element should be a list created by \code{createAnalysisSpecification}}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Examples}{
+\if{html}{\out{<div class="r example copy">}}
+\preformatted{analysis1 <- createAnalysisSpecification(targetCohorts1, eventCohorts1, ...)
+analysis2 <- createAnalysisSpecification(targetCohorts2, eventCohorts2, ...)
+multiSpec <- createMultiAnalysisModuleSpecification(list(spec1, spec2))
+}
+\if{html}{\out{</div>}}
+
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-TreatmentPatternsModule-createAnalysisSpecification"></a>}}
+\if{latex}{\out{\hypertarget{method-TreatmentPatternsModule-createAnalysisSpecification}{}}}
+\subsection{Method \code{createAnalysisSpecification()}}{
+Creates a settings list describing a TreatmentPatterns analysis. This specification is used by createMultiAnalysisModuleSpecification
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{TreatmentPatternsModule$createAnalysisSpecification(
+  targetCohorts,
+  eventCohorts,
+  exitCohorts = list(),
+  description = "",
+  includeTreatments = NULL,
+  indexDateOffset = NULL,
+  minEraDuration = 0,
+  splitEventCohorts = NULL,
+  splitTime = NULL,
+  eraCollapseSize = 30,
+  combinationWindow = 30,
+  minPostCombinationDuration = 30,
+  filterTreatments = "First",
+  maxPathLength = 5,
+  ageWindow = 5,
+  minCellCount = 1,
+  censorType = "minCellCount",
+  overlapMethod = "truncate",
+  concatTargets = TRUE,
+  startAnchor = "startDate",
+  windowStart = 0,
+  endAnchor = "endDate",
+  windowEnd = 0,
+  stratify = FALSE
+)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{targetCohorts}}{(\code{list()})\cr
+List of target cohorts in list-of-lists form:
+e.g. \code{list(list(1, "Hypertension"), list(2, "Diabetes"))}.Each inner list must contain \code{cohortId} (integer) and \code{cohortName} (string)}
+
+\item{\code{eventCohorts}}{(\code{list()})\cr
+Same structure as \code{targetCohorts}. These cohorts are treated as events/treatments}
+
+\item{\code{exitCohorts}}{(\code{list()})\cr
+Same structure; if provided these are treated as exit cohorts}
+
+\item{\code{description}}{(\code{character(1)})\cr
+Description for analysis}
+
+\item{\code{includeTreatments}}{(\code{character(1)}: \code{"startDate"})\cr
+\code{DEPRECATED}
+\describe{
+\item{\code{"startDate"}}{Include treatments after the target cohort start date and onwards.}
+\item{\code{"endDate"}}{Include treatments before target cohort end date and before.}
+}}
+
+\item{\code{indexDateOffset}}{(\code{integer(1)}: \code{0})\cr
+\code{DEPRECATED}
+Offset the index date of the \code{Target} cohort.}
+
+\item{\code{minEraDuration}}{(\code{integer(1)}: \code{0})\cr
+Minimum time an event era should last to be included in analysis}
+
+\item{\code{splitEventCohorts}}{(\code{character(n)}: \code{""})\cr
+Specify event cohort to split in acute (< X days) and therapy (>= X days)}
+
+\item{\code{splitTime}}{(\code{integer(1)}: \code{30})\cr
+Specify number of days (X) at which each of the split event cohorts should
+be split in acute and therapy}
+
+\item{\code{eraCollapseSize}}{(\code{integer(1)}: \code{30})\cr
+Window of time between which two eras of the same event cohort are collapsed
+into one era}
+
+\item{\code{combinationWindow}}{(\code{integer(1)}: \code{30})\cr
+Window of time two event cohorts need to overlap to be considered a
+combination treatment}
+
+\item{\code{minPostCombinationDuration}}{(\code{integer(1)}: \code{30})\cr
+Minimum time an event era before or after a generated combination treatment
+should last to be included in analysis}
+
+\item{\code{filterTreatments}}{(\code{character(1)}: \code{"First"} ["first", "Changes", "all"])\cr
+Select first occurrence of (‘First’); changes between (‘Changes’); or all
+event cohorts (‘All’).}
+
+\item{\code{maxPathLength}}{(\code{integer(1)}: \code{5})\cr
+Maximum number of steps included in treatment pathway}
+
+\item{\code{ageWindow}}{(\code{integer(n)}: \code{10})\cr
+Number of years to bin age groups into. It may also be a vector of integers.
+I.e. \code{c(0, 18, 150)} which will results in age group \code{0-18} which includes
+subjects \verb{< 19}. And age group \code{18-150} which includes subjects \verb{> 18}.}
+
+\item{\code{minCellCount}}{(\code{integer(1)}: \code{5})\cr
+Minimum count required per pathway. Censors data below \code{x} as \verb{<x}. This
+minimum value will carry over to the sankey diagram and sunburst plot.}
+
+\item{\code{censorType}}{(\code{character(1)})\cr
+\describe{
+\item{\code{"minCellCount"}}{Censors pathways <\code{minCellCount} to \code{minCellCount}.}
+\item{\code{"remove"}}{Censors pathways <\code{minCellCount} by removing them completely.}
+\item{\code{"mean"}}{Censors pathways <\code{minCellCount} to the mean of all frequencies below \code{minCellCount}}
+}}
+
+\item{\code{overlapMethod}}{(\code{character(1)}: \code{"truncate"}) Method to decide how to deal
+with overlap that is not significant enough for combination. \code{"keep"} will
+keep the dates as is. \code{"truncate"} truncates the first occurring event to
+the start date of the next event.}
+
+\item{\code{concatTargets}}{(\code{logical(1)}: \code{TRUE}) Should multiple target cohorts for the same person be concatenated or not?}
+
+\item{\code{startAnchor}}{(\code{character(1)}: \code{"startDate"}) Start date anchor. One of: \code{"startDate"}, \code{"endDate"}}
+
+\item{\code{windowStart}}{(\code{numeric(1)}: \code{0}) Offset for \code{startAnchor} in days.}
+
+\item{\code{endAnchor}}{(\code{character(1)}: \code{"endDate"}) End date anchor. One of: \code{"startDate"}, \code{"endDate"}}
+
+\item{\code{windowEnd}}{(\code{numeric(1)}: \code{0}) Offset for \code{endAnchor} in days.}
+
+\item{\code{stratify}}{(\code{logical(1)})\cr
+This will perform pairwise stratification between age, sex, and index year if set TRUE}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Details}{
+\itemize{
+\item cohortName must not contain \code{-} or \code{+}. Cohort names are validated as
+(perl-compatible) regular expressions. If invalid, an informative error is
+raised.
+}
+}
+
+\subsection{Returns}{
+A \code{list} describing analysis settings. Keys include:
+\itemize{
+\item \code{cohorts}: list of cohort definitions (each item has \code{cohortId},
+\code{cohortName}, \code{type})
+\item all parameters passed to this function (same names)
+}
 }
 }
 \if{html}{\out{<hr>}}

--- a/man/TreatmentPatternsModule.Rd
+++ b/man/TreatmentPatternsModule.Rd
@@ -6,16 +6,6 @@
 \description{
 Characterization and description of patterns of events (cohorts). against the OMOP Common Data Model.
 }
-\examples{
-
-## ------------------------------------------------
-## Method `TreatmentPatternsModule$createMultiAnalysisModuleSpecification`
-## ------------------------------------------------
-
-analysis1 <- createAnalysisSpecification(analysisId1, targetCohorts1, eventCohorts1, ...)
-analysis2 <- createAnalysisSpecification(analysisId2, targetCohorts2, eventCohorts2, ...)
-multiSpec <- createMultiAnalysisModuleSpecification(list(spec1, spec2))
-}
 \section{Super class}{
 \code{\link[Strategus:StrategusModule]{Strategus::StrategusModule}} -> \code{TreatmentPatternsModule}
 }
@@ -322,16 +312,6 @@ Each element should be a list created by \code{createAnalysisSpecification}}
 }
 \if{html}{\out{</div>}}
 }
-\subsection{Examples}{
-\if{html}{\out{<div class="r example copy">}}
-\preformatted{analysis1 <- createAnalysisSpecification(targetCohorts1, eventCohorts1, ...)
-analysis2 <- createAnalysisSpecification(targetCohorts2, eventCohorts2, ...)
-multiSpec <- createMultiAnalysisModuleSpecification(list(spec1, spec2))
-}
-\if{html}{\out{</div>}}
-
-}
-
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-TreatmentPatternsModule-createAnalysisSpecification"></a>}}

--- a/tests/testthat/test-TreatmentPatterns.R
+++ b/tests/testthat/test-TreatmentPatterns.R
@@ -8,7 +8,6 @@ test_that("TreatmentPatterns Backwards Compatibility ", {
   on.exit(unlink(tempDir, recursive = TRUE))
 
   testSettings <- generateCohortTable()
-
   tp <- Strategus::TreatmentPatternsModule$new()
 
   modSpec <- tp$createModuleSpecifications(
@@ -121,55 +120,20 @@ test_that("TreatmentPatterns execute single analysis", {
 
 test_that("Bad Cohort Names", {
   skip_if(!require("TreatmentPatterns", quietly = TRUE, character.only = TRUE, warn.conflicts = FALSE))
-
-  tempDir <- file.path(tempdir(), "Strategus-TP")
-  on.exit(unlink(tempDir, recursive = TRUE))
-
-  testSettings <- generateCohortTable()
   tp <- Strategus::TreatmentPatternsModule$new()
+
+
+  testTable1 <- data.frame(
+    cohortId = c(8,1,3,0),
+    cohortName = c("Viral+Sinusitis", "+Acetaminophen", "Aspirin-", "Death"),
+    type = c("target", "event", "event", "exit")
+  )
 
   expect_error(
     modSpecs <- list(
       tp$createModuleSpecifications(
         analysisId = 8,
-        targetCohorts = list(
-          list(8, "Viral+Sinusitis")
-        ),
-        eventCohorts = list(
-          list(1, "Acetaminophen"),
-          list(3, "Aspirin"),
-          list(6, "Doxylamin")
-        ),
-        exitCohorts = list(
-          list(8, "death")
-        ),
-        startAnchor = "startDate",
-        windowStart = 0,
-        endAnchor = "endDate",
-        windowEnd = 0,
-        minEraDuration = 7,
-        splitEventCohorts = NULL,
-        splitTime = NULL,
-        eraCollapseSize = 14,
-        combinationWindow = 7,
-        minPostCombinationDuration = 7,
-        filterTreatments = "First",
-        maxPathLength = 5
-      ),
-      tp$createModuleSpecifications(
-        analysisId = 10,
-        targetCohorts = list(
-          list(8, "ViralSinusitis")
-        ),
-        eventCohorts = list(
-          list(1, "Acetaminophen"),
-          list(3, "Aspirin"),
-          list(6, "Doxy-lamin"),
-          list(7, "Penicil+linV")
-        ),
-        exitCohorts = list(
-          list(8, "death")
-        ),
+        cohorts = testTable1,
         startAnchor = "startDate",
         windowStart = 0,
         endAnchor = "endDate",
@@ -186,53 +150,20 @@ test_that("Bad Cohort Names", {
     ),
     "Invalid target cohort name 'Viral\\+Sinusitis': Invalid target cohort name; remove -/\\+"
   )
-
-  expect_error(
-    modSpecs <- list(
-      tp$createModuleSpecifications(
-        analysisId = 8,
-        targetCohorts = list(
-          list(8, "ViralSinusitis")
-        ),
-        eventCohorts = NULL,
-        exitCohorts = list(
-          list(8, "death")
-        ),
-        startAnchor = "startDate",
-        windowStart = 0,
-        endAnchor = "endDate",
-        windowEnd = 0,
-        minEraDuration = 7,
-        splitEventCohorts = NULL,
-        splitTime = NULL,
-        eraCollapseSize = 14,
-        combinationWindow = 7,
-        minPostCombinationDuration = 7,
-        filterTreatments = "First",
-        maxPathLength = 5
-      )
-    ),
-    "specify cohort or targetCohorts and eventCohorts"
-  )
 })
 
 test_that("Unique Analysis Ids", {
-  tp <- Strategus::TreatmentPatternsModule$new()
+  skip_if(!require("TreatmentPatterns", quietly = TRUE, character.only = TRUE, warn.conflicts = FALSE))
 
+  tempDir <- file.path(tempdir(), "Strategus-TP")
+  on.exit(unlink(tempDir, recursive = TRUE))
+
+  testSettings <- generateCohortTable()
+  tp <- Strategus::TreatmentPatternsModule$new()
 
   modSpecs <- list(
     tp$createModuleSpecifications(
-      targetCohorts = list(
-        list(8, "ViralSinusitis")
-      ),
-      eventCohorts = list(
-        list(1, "Acetaminophen"),
-        list(3, "Aspirin"),
-        list(6, "Doxylamin")
-      ),
-      exitCohorts = list(
-        list(8, "death")
-      ),
+      cohorts = testSettings$cohorts,
       startAnchor = "startDate",
       windowStart = 0,
       endAnchor = "endDate",
@@ -247,18 +178,7 @@ test_that("Unique Analysis Ids", {
       maxPathLength = 5
     ),
     tp$createModuleSpecifications(
-      targetCohorts = list(
-        list(8, "ViralSinusitis")
-      ),
-      eventCohorts = list(
-        list(1, "Acetaminophen"),
-        list(3, "Aspirin"),
-        list(6, "Doxylamin"),
-        list(7, "PenicillinV")
-      ),
-      exitCohorts = list(
-        list(8, "death")
-      ),
+      cohorts = testSettings$cohorts,
       startAnchor = "startDate",
       windowStart = 0,
       endAnchor = "endDate",
@@ -273,11 +193,11 @@ test_that("Unique Analysis Ids", {
       maxPathLength = 5
     )
   )
-
   expect_error(
     tp$createMultiAnalysisModuleSpecification(tpAnalysisList = modSpecs),
     "Each analysis need unique id"
   )
+
 })
 
 test_that("TreatmentPatterns: execute method with multiple analysis", {
@@ -292,14 +212,7 @@ test_that("TreatmentPatterns: execute method with multiple analysis", {
   modSpecs <- list(
     tp$createModuleSpecifications(
       analysisId = 8,
-      targetCohorts = list(
-        list(8, "ViralSinusitis")
-      ),
-      eventCohorts = list(
-        list(1, "Acetaminophen"),
-        list(3, "Aspirin"),
-        list(6, "Doxylamin")
-      ),
+      cohorts = testSettings$cohorts,
       startAnchor = "startDate",
       windowStart = 0,
       endAnchor = "endDate",
@@ -315,16 +228,7 @@ test_that("TreatmentPatterns: execute method with multiple analysis", {
     ),
     tp$createModuleSpecifications(
       analysisId = 10,
-      targetCohorts = list(
-        list(8, "ViralSinusitis")
-      ),
-      eventCohorts = list(
-        list(1, "Acetaminophen"),
-        list(7, "PenicillinV")
-      ),
-      exitCohorts = list(
-        list(8, "death")
-      ),
+      cohorts = testSettings$cohorts,
       includeTreatments = "startDate",
       indexDateOffset = 0,
       minEraDuration = 7,
@@ -386,14 +290,7 @@ test_that("TreatmentPatterns: pathway failed", {
   modSpecs <- list(
     tp$createModuleSpecifications(
       analysisId = 8,
-      targetCohorts = list(
-        list(8, "ViralSinusitis")
-      ),
-      eventCohorts = list(
-        list(1, "Acetaminophen"),
-        list(3, "Aspirin"),
-        list(6, "Doxylamin")
-      ),
+      cohorts = testSettings$cohorts,
       startAnchor = "startDate",
       windowStart = 0,
       endAnchor = "endDate",

--- a/tests/testthat/test-TreatmentPatterns.R
+++ b/tests/testthat/test-TreatmentPatterns.R
@@ -30,12 +30,14 @@ test_that("TreatmentPatterns: execute method", {
   analysisSpecifications <- Strategus::createEmptyAnalysisSpecifications() |>
     Strategus::addTreatmentPatternsModuleSpecifications(modSpec)
 
+  workFolder <- file.path(tempDir, "work_folder")
+
   executionSettings <- Strategus::createCdmExecutionSettings(
     workDatabaseSchema = testSettings$resultSchema,
     cdmDatabaseSchema = testSettings$cdmSchema,
     cohortTableNames = CohortGenerator::getCohortTableNames(cohortTable = "cohort_table"),
     tempEmulationSchema = NULL,
-    workFolder = file.path(tempDir, "work_folder"),
+    workFolder = workFolder,
     resultsFolder = file.path(tempDir, "results_folder"),
     logFileName = "log.txt",
     minCellCount = 5,
@@ -57,6 +59,7 @@ test_that("TreatmentPatterns: execute method", {
   expect_true(file.exists(file.path(executionSettings$resultsFolder, tp$moduleName, paste0(tp$tablePrefix, "summary_event_duration.csv"))))
   expect_true(file.exists(file.path(executionSettings$resultsFolder, tp$moduleName, paste0(tp$tablePrefix, "treatment_pathways.csv"))))
   expect_true(file.exists(file.path(executionSettings$resultsFolder, tp$moduleName, "resultsDataModelSpecification.csv")))
+  expect_true(file.exists(file.path(workFolder, "TreatmentPatternsModule/", "passed_pathway_runs.csv")))
 })
 
 
@@ -73,6 +76,7 @@ test_that("Bad Cohort Names", {
   expect_error(
     modSpecs <- list(
       tp$createAnalysisSpecification(
+        analysisId = 8,
         targetCohorts = list(
           list(8, "Viral+Sinusitis")
         ),
@@ -96,6 +100,7 @@ test_that("Bad Cohort Names", {
         maxPathLength = 5
       ),
       tp$createAnalysisSpecification(
+        analysisId = 10,
         targetCohorts = list(
           list(8, "ViralSinusitis")
         ),
@@ -135,6 +140,7 @@ test_that("TreatmentPatterns: execute method with multiple analysis", {
 
   modSpecs <- list(
     tp$createAnalysisSpecification(
+      analysisId = 8,
       targetCohorts = list(
         list(8, "ViralSinusitis")
       ),
@@ -157,6 +163,7 @@ test_that("TreatmentPatterns: execute method with multiple analysis", {
       maxPathLength = 5
     ),
     tp$createAnalysisSpecification(
+      analysisId = 10,
       targetCohorts = list(
         list(8, "ViralSinusitis")
       ),

--- a/tests/testthat/test-TreatmentPatterns.R
+++ b/tests/testthat/test-TreatmentPatterns.R
@@ -1,7 +1,65 @@
 library(testthat)
 library(dplyr)
 
-test_that("TreatmentPatterns: execute method", {
+test_that("TreatmentPatterns Backwards Compatibility ", {
+  skip_if(!require("TreatmentPatterns", quietly = TRUE, character.only = TRUE, warn.conflicts = FALSE))
+
+  tempDir <- file.path(tempdir(), "Strategus-TP")
+  on.exit(unlink(tempDir, recursive = TRUE))
+
+  testSettings <- generateCohortTable()
+
+  tp <- Strategus::TreatmentPatternsModule$new()
+
+  modSpec <- tp$createModuleSpecifications(
+    cohorts = testSettings$cohorts,
+    includeTreatments = "startDate",
+    indexDateOffset = 0,
+    minEraDuration = 7,
+    splitEventCohorts = NULL,
+    splitTime = NULL,
+    eraCollapseSize = 14,
+    combinationWindow = 7,
+    minPostCombinationDuration = 7,
+    filterTreatments = "First",
+    maxPathLength = 5
+  )
+
+  analysisSpecifications <- Strategus::createEmptyAnalysisSpecifications() |>
+    Strategus::addTreatmentPatternsModuleSpecifications(modSpec)
+
+  executionSettings <- Strategus::createCdmExecutionSettings(
+    workDatabaseSchema = testSettings$resultSchema,
+    cdmDatabaseSchema = testSettings$cdmSchema,
+    cohortTableNames = CohortGenerator::getCohortTableNames(cohortTable = "cohort_table"),
+    tempEmulationSchema = NULL,
+    workFolder = file.path(tempDir, "work_folder"),
+    resultsFolder = file.path(tempDir, "results_folder"),
+    logFileName = "log.txt",
+    minCellCount = 5,
+    incremental = FALSE,
+    maxCores = 1
+  )
+
+  Strategus::execute(
+    connectionDetails = testSettings$connectionDetails,
+    analysisSpecifications = analysisSpecifications,
+    executionSettings = executionSettings
+  )
+
+
+  expect_true(file.exists(file.path(executionSettings$resultsFolder, tp$moduleName, paste0(tp$tablePrefix, "attrition.csv"))))
+  expect_true(file.exists(file.path(executionSettings$resultsFolder, tp$moduleName, paste0(tp$tablePrefix, "counts_age.csv"))))
+  expect_true(file.exists(file.path(executionSettings$resultsFolder, tp$moduleName, paste0(tp$tablePrefix, "counts_sex.csv"))))
+  expect_true(file.exists(file.path(executionSettings$resultsFolder, tp$moduleName, paste0(tp$tablePrefix, "counts_year.csv"))))
+  expect_true(file.exists(file.path(executionSettings$resultsFolder, tp$moduleName, paste0(tp$tablePrefix, "metadata.csv"))))
+  expect_true(file.exists(file.path(executionSettings$resultsFolder, tp$moduleName, paste0(tp$tablePrefix, "summary_event_duration.csv"))))
+  expect_true(file.exists(file.path(executionSettings$resultsFolder, tp$moduleName, paste0(tp$tablePrefix, "treatment_pathways.csv"))))
+  expect_true(file.exists(file.path(executionSettings$resultsFolder, tp$moduleName, "resultsDataModelSpecification.csv")))
+})
+
+
+test_that("TreatmentPatterns execute single analysis", {
   skip_if(!require("TreatmentPatterns", quietly = TRUE, character.only = TRUE, warn.conflicts = FALSE))
 
   tempDir <- file.path(tempdir(), "Strategus-TP")
@@ -70,7 +128,7 @@ test_that("Bad Cohort Names", {
   on.exit(unlink(tempDir, recursive = TRUE))
 
   testSettings <- generateCohortTable()
-  tp <- Strategus::TreatmentPatternsModule$new
+  tp <- Strategus::TreatmentPatternsModule$new()
 
 
   expect_error(
@@ -88,8 +146,10 @@ test_that("Bad Cohort Names", {
         exitCohorts = list(
           list(8, "death")
         ),
-        includeTreatments = "startDate",
-        indexDateOffset = 0,
+        startAnchor = "startDate",
+        windowStart = 0,
+        endAnchor = "endDate",
+        windowEnd = 0,
         minEraDuration = 7,
         splitEventCohorts = NULL,
         splitTime = NULL,
@@ -113,8 +173,10 @@ test_that("Bad Cohort Names", {
         exitCohorts = list(
           list(8, "death")
         ),
-        includeTreatments = "startDate",
-        indexDateOffset = 0,
+        startAnchor = "startDate",
+        windowStart = 0,
+        endAnchor = "endDate",
+        windowEnd = 0,
         minEraDuration = 7,
         splitEventCohorts = NULL,
         splitTime = NULL,
@@ -124,7 +186,36 @@ test_that("Bad Cohort Names", {
         filterTreatments = "First",
         maxPathLength = 5
       )
-    )
+    ),
+    "Invalid target cohort name 'Viral\\+Sinusitis': Invalid target cohort name; remove -/\\+"
+  )
+
+  expect_error(
+    modSpecs <- list(
+      tp$createAnalysisSpecification(
+        analysisId = 8,
+        targetCohorts = list(
+          list(8, "ViralSinusitis")
+        ),
+        eventCohorts = NULL,
+        exitCohorts = list(
+          list(8, "death")
+        ),
+        startAnchor = "startDate",
+        windowStart = 0,
+        endAnchor = "endDate",
+        windowEnd = 0,
+        minEraDuration = 7,
+        splitEventCohorts = NULL,
+        splitTime = NULL,
+        eraCollapseSize = 14,
+        combinationWindow = 7,
+        minPostCombinationDuration = 7,
+        filterTreatments = "First",
+        maxPathLength = 5
+      )
+    ),
+    "targetCohorts or eventCohorts are empty"
   )
 })
 
@@ -174,10 +265,8 @@ test_that("TreatmentPatterns: execute method with multiple analysis", {
       exitCohorts = list(
         list(8, "death")
       ),
-      startAnchor = "startDate",
-      windowStart = 0,
-      endAnchor = "endDate",
-      windowEnd = 0,
+      includeTreatments = "startDate",
+      indexDateOffset = 0,
       minEraDuration = 7,
       splitEventCohorts = NULL,
       splitTime = NULL,
@@ -185,7 +274,7 @@ test_that("TreatmentPatterns: execute method with multiple analysis", {
       combinationWindow = 7,
       minPostCombinationDuration = 7,
       filterTreatments = "First",
-      maxPathLength = 7
+      maxPathLength = 5
     )
   )
 
@@ -223,4 +312,77 @@ test_that("TreatmentPatterns: execute method with multiple analysis", {
   expect_true(file.exists(file.path(executionSettings$resultsFolder, tp$moduleName, paste0(tp$tablePrefix, "treatment_pathways.csv"))))
   expect_true(file.exists(file.path(executionSettings$resultsFolder, tp$moduleName, "resultsDataModelSpecification.csv")))
   expect_true(file.exists(file.path(executionSettings$resultsFolder, tp$moduleName, paste0(tp$tablePrefix, "analysis_cohorts.csv"))))
+})
+
+
+
+test_that("TreatmentPatterns:  pathway failed", {
+  skip_if(!require("TreatmentPatterns", quietly = TRUE, character.only = TRUE, warn.conflicts = FALSE))
+
+  tempDir <- file.path(tempdir(), "Strategus-TP")
+  on.exit(unlink(tempDir, recursive = TRUE))
+
+  testSettings <- generateCohortTable()
+  tp <- Strategus::TreatmentPatternsModule$new()
+
+  modSpecs <- list(
+    tp$createAnalysisSpecification(
+      analysisId = 8,
+      targetCohorts = list(
+        list(8, "ViralSinusitis")
+      ),
+      eventCohorts = list(
+        list(1, "Acetaminophen"),
+        list(3, "Aspirin"),
+        list(6, "Doxylamin")
+      ),
+      startAnchor = "startDate",
+      windowStart = 0,
+      endAnchor = "endDate",
+      windowEnd = 0,
+      minEraDuration = 7,
+      splitEventCohorts = NULL,
+      splitTime = NULL,
+      eraCollapseSize = 14,
+      combinationWindow = 7,
+      minPostCombinationDuration = 7,
+      filterTreatments = "First",
+      maxPathLength = 5
+    )
+  )
+
+
+  # install mock into the package namespace (bare name computePathways; NO backticks or pkg:: prefix)
+  testthat::local_mocked_bindings(
+    computePathways = function(...) stop("forced computePathways failure"),
+    .package = "TreatmentPatterns"
+  )
+
+  workFolder <- file.path(tempDir, "work_folder")
+
+  specifications <- tp$createMultiAnalysisModuleSpecification(tpAnalysisList = modSpecs)
+
+  analysisSpecifications <- Strategus::createEmptyAnalysisSpecifications() |>
+    Strategus::addTreatmentPatternsModuleSpecifications(specifications)
+
+  executionSettings <- Strategus::createCdmExecutionSettings(
+    workDatabaseSchema = testSettings$resultSchema,
+    cdmDatabaseSchema = testSettings$cdmSchema,
+    cohortTableNames = CohortGenerator::getCohortTableNames(cohortTable = "cohort_table"),
+    tempEmulationSchema = NULL,
+    workFolder = workFolder,
+    resultsFolder = file.path(tempDir, "results_folder"),
+    logFileName = "log.txt",
+    minCellCount = 5,
+    incremental = FALSE,
+    maxCores = 1
+  )
+
+  Strategus::execute(
+    connectionDetails = testSettings$connectionDetails,
+    analysisSpecifications = analysisSpecifications,
+    executionSettings = executionSettings
+  )
+
+  expect_true(file.exists(file.path(workFolder, "TreatmentPatternsModule/", "failed_pathway_runs.csv")))
 })

--- a/tests/testthat/test-TreatmentPatterns.R
+++ b/tests/testthat/test-TreatmentPatterns.R
@@ -58,7 +58,6 @@ test_that("TreatmentPatterns Backwards Compatibility ", {
   expect_true(file.exists(file.path(executionSettings$resultsFolder, tp$moduleName, "resultsDataModelSpecification.csv")))
 })
 
-
 test_that("TreatmentPatterns execute single analysis", {
   skip_if(!require("TreatmentPatterns", quietly = TRUE, character.only = TRUE, warn.conflicts = FALSE))
 
@@ -120,7 +119,6 @@ test_that("TreatmentPatterns execute single analysis", {
   expect_true(file.exists(file.path(workFolder, "TreatmentPatternsModule/", "passed_pathway_runs.csv")))
 })
 
-
 test_that("Bad Cohort Names", {
   skip_if(!require("TreatmentPatterns", quietly = TRUE, character.only = TRUE, warn.conflicts = FALSE))
 
@@ -130,10 +128,9 @@ test_that("Bad Cohort Names", {
   testSettings <- generateCohortTable()
   tp <- Strategus::TreatmentPatternsModule$new()
 
-
   expect_error(
     modSpecs <- list(
-      tp$createAnalysisSpecification(
+      tp$createModuleSpecifications(
         analysisId = 8,
         targetCohorts = list(
           list(8, "Viral+Sinusitis")
@@ -159,7 +156,7 @@ test_that("Bad Cohort Names", {
         filterTreatments = "First",
         maxPathLength = 5
       ),
-      tp$createAnalysisSpecification(
+      tp$createModuleSpecifications(
         analysisId = 10,
         targetCohorts = list(
           list(8, "ViralSinusitis")
@@ -192,7 +189,7 @@ test_that("Bad Cohort Names", {
 
   expect_error(
     modSpecs <- list(
-      tp$createAnalysisSpecification(
+      tp$createModuleSpecifications(
         analysisId = 8,
         targetCohorts = list(
           list(8, "ViralSinusitis")
@@ -215,10 +212,73 @@ test_that("Bad Cohort Names", {
         maxPathLength = 5
       )
     ),
-    "targetCohorts or eventCohorts are empty"
+    "specify cohort or targetCohorts and eventCohorts"
   )
 })
 
+test_that("Unique Analysis Ids", {
+  tp <- Strategus::TreatmentPatternsModule$new()
+
+
+  modSpecs <- list(
+    tp$createModuleSpecifications(
+      targetCohorts = list(
+        list(8, "ViralSinusitis")
+      ),
+      eventCohorts = list(
+        list(1, "Acetaminophen"),
+        list(3, "Aspirin"),
+        list(6, "Doxylamin")
+      ),
+      exitCohorts = list(
+        list(8, "death")
+      ),
+      startAnchor = "startDate",
+      windowStart = 0,
+      endAnchor = "endDate",
+      windowEnd = 0,
+      minEraDuration = 7,
+      splitEventCohorts = NULL,
+      splitTime = NULL,
+      eraCollapseSize = 14,
+      combinationWindow = 7,
+      minPostCombinationDuration = 7,
+      filterTreatments = "First",
+      maxPathLength = 5
+    ),
+    tp$createModuleSpecifications(
+      targetCohorts = list(
+        list(8, "ViralSinusitis")
+      ),
+      eventCohorts = list(
+        list(1, "Acetaminophen"),
+        list(3, "Aspirin"),
+        list(6, "Doxylamin"),
+        list(7, "PenicillinV")
+      ),
+      exitCohorts = list(
+        list(8, "death")
+      ),
+      startAnchor = "startDate",
+      windowStart = 0,
+      endAnchor = "endDate",
+      windowEnd = 0,
+      minEraDuration = 7,
+      splitEventCohorts = NULL,
+      splitTime = NULL,
+      eraCollapseSize = 14,
+      combinationWindow = 7,
+      minPostCombinationDuration = 7,
+      filterTreatments = "First",
+      maxPathLength = 5
+    )
+  )
+
+  expect_error(
+    tp$createMultiAnalysisModuleSpecification(tpAnalysisList = modSpecs),
+    "Each analysis need unique id"
+  )
+})
 
 test_that("TreatmentPatterns: execute method with multiple analysis", {
   skip_if(!require("TreatmentPatterns", quietly = TRUE, character.only = TRUE, warn.conflicts = FALSE))
@@ -230,7 +290,7 @@ test_that("TreatmentPatterns: execute method with multiple analysis", {
   tp <- Strategus::TreatmentPatternsModule$new()
 
   modSpecs <- list(
-    tp$createAnalysisSpecification(
+    tp$createModuleSpecifications(
       analysisId = 8,
       targetCohorts = list(
         list(8, "ViralSinusitis")
@@ -253,7 +313,7 @@ test_that("TreatmentPatterns: execute method with multiple analysis", {
       filterTreatments = "First",
       maxPathLength = 5
     ),
-    tp$createAnalysisSpecification(
+    tp$createModuleSpecifications(
       analysisId = 10,
       targetCohorts = list(
         list(8, "ViralSinusitis")
@@ -314,9 +374,7 @@ test_that("TreatmentPatterns: execute method with multiple analysis", {
   expect_true(file.exists(file.path(executionSettings$resultsFolder, tp$moduleName, paste0(tp$tablePrefix, "analysis_cohorts.csv"))))
 })
 
-
-
-test_that("TreatmentPatterns:  pathway failed", {
+test_that("TreatmentPatterns: pathway failed", {
   skip_if(!require("TreatmentPatterns", quietly = TRUE, character.only = TRUE, warn.conflicts = FALSE))
 
   tempDir <- file.path(tempdir(), "Strategus-TP")
@@ -326,7 +384,7 @@ test_that("TreatmentPatterns:  pathway failed", {
   tp <- Strategus::TreatmentPatternsModule$new()
 
   modSpecs <- list(
-    tp$createAnalysisSpecification(
+    tp$createModuleSpecifications(
       analysisId = 8,
       targetCohorts = list(
         list(8, "ViralSinusitis")

--- a/tests/testthat/test-TreatmentPatterns.R
+++ b/tests/testthat/test-TreatmentPatterns.R
@@ -56,3 +56,158 @@ test_that("TreatmentPatterns: execute method", {
   expect_true(file.exists(file.path(executionSettings$resultsFolder, tp$moduleName, paste0(tp$tablePrefix, "treatment_pathways.csv"))))
   expect_true(file.exists(file.path(executionSettings$resultsFolder, tp$moduleName, "resultsDataModelSpecification.csv")))
 })
+
+
+test_that("Bad Cohort Names", {
+  skip_if(!require("TreatmentPatterns", quietly = TRUE, character.only = TRUE, warn.conflicts = FALSE))
+
+  tempDir <- file.path(tempdir(), "Strategus-TP")
+  on.exit(unlink(tempDir, recursive = TRUE))
+
+  testSettings <- generateCohortTable()
+  tp <- Strategus::TreatmentPatternsModule$new
+
+
+  expect_error(
+    modSpecs <- list(
+      tp$createAnalysisSpecification(
+        targetCohorts = list(
+          list(8, "Viral+Sinusitis")
+        ),
+        eventCohorts = list(
+          list(1, "Acetaminophen"),
+          list(3, "Aspirin"),
+          list(6, "Doxylamin")
+        ),
+        exitCohorts = list(
+          list(8, "death")
+        ),
+        includeTreatments = "startDate",
+        indexDateOffset = 0,
+        minEraDuration = 7,
+        splitEventCohorts = NULL,
+        splitTime = NULL,
+        eraCollapseSize = 14,
+        combinationWindow = 7,
+        minPostCombinationDuration = 7,
+        filterTreatments = "First",
+        maxPathLength = 5
+      ),
+      tp$createAnalysisSpecification(
+        targetCohorts = list(
+          list(8, "ViralSinusitis")
+        ),
+        eventCohorts = list(
+          list(1, "Acetaminophen"),
+          list(3, "Aspirin"),
+          list(6, "Doxy-lamin"),
+          list(7, "Penicil+linV")
+        ),
+        exitCohorts = list(
+          list(8, "death")
+        ),
+        includeTreatments = "startDate",
+        indexDateOffset = 0,
+        minEraDuration = 7,
+        splitEventCohorts = NULL,
+        splitTime = NULL,
+        eraCollapseSize = 14,
+        combinationWindow = 7,
+        minPostCombinationDuration = 7,
+        filterTreatments = "First",
+        maxPathLength = 5
+      )
+    )
+  )
+})
+
+
+test_that("TreatmentPatterns: execute method with multiple analysis", {
+  skip_if(!require("TreatmentPatterns", quietly = TRUE, character.only = TRUE, warn.conflicts = FALSE))
+
+  tempDir <- file.path(tempdir(), "Strategus-TP")
+  on.exit(unlink(tempDir, recursive = TRUE))
+
+  testSettings <- generateCohortTable()
+  tp <- Strategus::TreatmentPatternsModule$new()
+
+  modSpecs <- list(
+    tp$createAnalysisSpecification(
+      targetCohorts = list(
+        list(8, "ViralSinusitis")
+      ),
+      eventCohorts = list(
+        list(1, "Acetaminophen"),
+        list(3, "Aspirin"),
+        list(6, "Doxylamin")
+      ),
+      includeTreatments = "startDate",
+      indexDateOffset = 0,
+      minEraDuration = 7,
+      splitEventCohorts = NULL,
+      splitTime = NULL,
+      eraCollapseSize = 14,
+      combinationWindow = 7,
+      minPostCombinationDuration = 7,
+      filterTreatments = "First",
+      maxPathLength = 5
+    ),
+    tp$createAnalysisSpecification(
+      targetCohorts = list(
+        list(8, "ViralSinusitis")
+      ),
+      eventCohorts = list(
+        list(1, "Acetaminophen"),
+        list(7, "PenicillinV")
+      ),
+      exitCohorts = list(
+        list(8, "death")
+      ),
+      includeTreatments = "startDate",
+      indexDateOffset = 0,
+      minEraDuration = 7,
+      splitEventCohorts = NULL,
+      splitTime = NULL,
+      eraCollapseSize = 14,
+      combinationWindow = 7,
+      minPostCombinationDuration = 7,
+      filterTreatments = "First",
+      maxPathLength = 5
+    )
+  )
+
+  specifications <- tp$createMultiAnalysisModuleSpecification(tpAnalysisList = modSpecs)
+
+  analysisSpecifications <- Strategus::createEmptyAnalysisSpecifications() |>
+    Strategus::addTreatmentPatternsModuleSpecifications(specifications)
+
+  executionSettings <- Strategus::createCdmExecutionSettings(
+    workDatabaseSchema = testSettings$resultSchema,
+    cdmDatabaseSchema = testSettings$cdmSchema,
+    cohortTableNames = CohortGenerator::getCohortTableNames(cohortTable = "cohort_table"),
+    tempEmulationSchema = NULL,
+    workFolder = file.path(tempDir, "work_folder"),
+    resultsFolder = file.path(tempDir, "results_folder"),
+    logFileName = "log.txt",
+    minCellCount = 5,
+    incremental = FALSE,
+    maxCores = 1
+  )
+
+  Strategus::execute(
+    connectionDetails = testSettings$connectionDetails,
+    analysisSpecifications = analysisSpecifications,
+    executionSettings = executionSettings
+  )
+
+
+  expect_true(file.exists(file.path(executionSettings$resultsFolder, tp$moduleName, paste0(tp$tablePrefix, "attrition.csv"))))
+  expect_true(file.exists(file.path(executionSettings$resultsFolder, tp$moduleName, paste0(tp$tablePrefix, "counts_age.csv"))))
+  expect_true(file.exists(file.path(executionSettings$resultsFolder, tp$moduleName, paste0(tp$tablePrefix, "counts_sex.csv"))))
+  expect_true(file.exists(file.path(executionSettings$resultsFolder, tp$moduleName, paste0(tp$tablePrefix, "counts_year.csv"))))
+  expect_true(file.exists(file.path(executionSettings$resultsFolder, tp$moduleName, paste0(tp$tablePrefix, "metadata.csv"))))
+  expect_true(file.exists(file.path(executionSettings$resultsFolder, tp$moduleName, paste0(tp$tablePrefix, "summary_event_duration.csv"))))
+  expect_true(file.exists(file.path(executionSettings$resultsFolder, tp$moduleName, paste0(tp$tablePrefix, "treatment_pathways.csv"))))
+  expect_true(file.exists(file.path(executionSettings$resultsFolder, tp$moduleName, "resultsDataModelSpecification.csv")))
+  expect_true(file.exists(file.path(executionSettings$resultsFolder, tp$moduleName, paste0(tp$tablePrefix, "analysis_cohorts.csv"))))
+})

--- a/tests/testthat/test-TreatmentPatterns.R
+++ b/tests/testthat/test-TreatmentPatterns.R
@@ -13,8 +13,10 @@ test_that("TreatmentPatterns: execute method", {
 
   modSpec <- tp$createModuleSpecifications(
     cohorts = testSettings$cohorts,
-    includeTreatments = "startDate",
-    indexDateOffset = 0,
+    startAnchor = "startDate",
+    windowStart = 0,
+    endAnchor = "endDate",
+    windowEnd = 0,
     minEraDuration = 7,
     splitEventCohorts = NULL,
     splitTime = NULL,
@@ -141,8 +143,10 @@ test_that("TreatmentPatterns: execute method with multiple analysis", {
         list(3, "Aspirin"),
         list(6, "Doxylamin")
       ),
-      includeTreatments = "startDate",
-      indexDateOffset = 0,
+      startAnchor = "startDate",
+      windowStart = 0,
+      endAnchor = "endDate",
+      windowEnd = 0,
       minEraDuration = 7,
       splitEventCohorts = NULL,
       splitTime = NULL,
@@ -163,8 +167,10 @@ test_that("TreatmentPatterns: execute method with multiple analysis", {
       exitCohorts = list(
         list(8, "death")
       ),
-      includeTreatments = "startDate",
-      indexDateOffset = 0,
+      startAnchor = "startDate",
+      windowStart = 0,
+      endAnchor = "endDate",
+      windowEnd = 0,
       minEraDuration = 7,
       splitEventCohorts = NULL,
       splitTime = NULL,
@@ -172,7 +178,7 @@ test_that("TreatmentPatterns: execute method with multiple analysis", {
       combinationWindow = 7,
       minPostCombinationDuration = 7,
       filterTreatments = "First",
-      maxPathLength = 5
+      maxPathLength = 7
     )
   )
 


### PR DESCRIPTION
This PR updates the TreatmentPatterns Module to enable multiple analyses to be run simultaneously.

### **Summary of Changes**

1. Added createModuleSpecification:
This function builds a TreatmentPatterns analysis spec from lists of target, event, and exit cohort definitions, converting them into the cohort data frame the package expects, and returns an analysis settings list.

2. Added createMultiAnalysisModuleSpecification:
This function takes a list of analysis specifications made by createAnalysisSpecification

3. Modified createModuleSpecification: 
I modified the return specification to be wrapped by a list so it matches the createMultiAnalysisModuleSpecification returned results. Now it returns a list in the form of list(tpAnalysisList = list())

4. Modified execute:
I modified this function so it can loop through the tpAnalysisList and run each treatment pattern. All the logs of passed and failed pathways are written to the treatment_pathway_runs.csv in the work folder. The execute method also makes a new table in the results folder called analysis_cohorts, which has the columns:
event_cohort_name, event_cohort_id, target_cohort_id, target_event_id, and analysis_id

5. Modified data model: 
Modified the model to allow the analysis_cohorts table to be inserted


eg.

tp <- TreatmentPatternsModule$new()

modSpecs <- list(
     tp$createAnalysisSpecification(...),
     tp$createAnalysisSpecification(...),
)

tpModuleSpecifications <- tp$createMultiAnalysisModuleSpecification(tpAnalysis = modSpecs)