### PR TITLE
Properly handle folder when performing zip operations

### DIFF
--- a/R/Module-CohortDiagnostics.R
+++ b/R/Module-CohortDiagnostics.R
@@ -90,7 +90,7 @@ CohortDiagnosticsModule <- R6::R6Class(
 
       # TODO: This is something CD does differently.
       # Find the results zip file in the results sub folder
-      resultsFolder <- private$jobContext$moduleExecutionSettings$resultsSubFolder
+      resultsFolder <- normalizePath(private$jobContext$moduleExecutionSettings$resultsSubFolder)
       zipFiles <- list.files(
         path = resultsFolder,
         pattern = "\\.zip$",
@@ -101,6 +101,8 @@ CohortDiagnosticsModule <- R6::R6Class(
         zipFileName <- zipFiles[1]
       } else {
         # Create a zip file from the results in the directory
+        oldWd <- setwd(resultsFolder)
+        on.exit(setwd(oldWd))
         DatabaseConnector::createZipFile(
           zipFile = "results.zip",
           files = list.files(resultsFolder, pattern = ".*\\.csv$"),

--- a/R/Module-CohortMethod.R
+++ b/R/Module-CohortMethod.R
@@ -105,7 +105,7 @@ CohortMethodModule <- R6::R6Class(
 
       # TODO: This is something CM does differently.
       # Find the results zip file in the results sub folder
-      resultsFolder <- private$jobContext$moduleExecutionSettings$resultsSubFolder
+      resultsFolder <- normalizePath(private$jobContext$moduleExecutionSettings$resultsSubFolder)
       zipFiles <- list.files(
         path = resultsFolder,
         pattern = "\\.zip$",
@@ -116,6 +116,8 @@ CohortMethodModule <- R6::R6Class(
         zipFileName <- zipFiles[1]
       } else {
         # Create a zip file from the results in the directory
+        oldWd <- setwd(resultsFolder)
+        on.exit(setwd(oldWd))
         DatabaseConnector::createZipFile(
           zipFile = "results.zip",
           files = list.files(resultsFolder, pattern = ".*\\.csv$"),

--- a/R/Module-SelfControlledCaseSeries.R
+++ b/R/Module-SelfControlledCaseSeries.R
@@ -119,7 +119,7 @@ SelfControlledCaseSeriesModule <- R6::R6Class(
 
       # TODO: This is something SCCS does differently.
       # Find the results zip file in the results sub folder
-      resultsFolder <- private$jobContext$moduleExecutionSettings$resultsSubFolder
+      resultsFolder <- normalizePath(private$jobContext$moduleExecutionSettings$resultsSubFolder)
       zipFiles <- list.files(
         path = resultsFolder,
         pattern = "\\.zip$",
@@ -130,6 +130,8 @@ SelfControlledCaseSeriesModule <- R6::R6Class(
         zipFileName <- zipFiles[1]
       } else {
         # Create a zip file from the results in the directory
+        oldWd <- setwd(resultsFolder)
+        on.exit(setwd(oldWd))
         DatabaseConnector::createZipFile(
           zipFile = "results.zip",
           files = list.files(resultsFolder, pattern = ".*\\.csv$"),

--- a/R/ShareResults.R
+++ b/R/ShareResults.R
@@ -22,6 +22,8 @@ zipResults <- function(resultsFolder, zipFile) {
     recursive = TRUE,
     full.names = TRUE
   )
+  oldWd <- setwd(resultsFolder)
+  on.exit(setwd(oldWd))
   DatabaseConnector::createZipFile(
     zipFile = zipFile,
     files = files,


### PR DESCRIPTION
Make sure we properly set (and later reset) the current working directory when working with zip files.

