### PR TITLE
Update to Prevent Tibble Failures During EvidenceSynthesis

### DIFF
--- a/R/Module-EvidenceSynthesis.R
+++ b/R/Module-EvidenceSynthesis.R
@@ -1316,6 +1316,15 @@ EvidenceSynthesisModule <- R6::R6Class(
   return(row)
 }
 
+.computeBalanceP <- function(sdm, sdmVariance, threshold) {
+  zUpper <- (abs(sdm) - threshold) / sqrt(sdmVariance)
+  pUpper <- pnorm(zUpper, lower.tail = FALSE)
+  zLower <- (-abs(sdm) - threshold) / sqrt(sdmVariance)
+  pLower <- pnorm(zLower, lower.tail = TRUE)
+  p <- pUpper + pLower
+  return(p)
+}
+
 .minOrNa <- function(x) {
   x <- x[!is.na(x)]
   if (length(x) == 0) {

--- a/R/Module-EvidenceSynthesis.R
+++ b/R/Module-EvidenceSynthesis.R
@@ -1268,65 +1268,52 @@ EvidenceSynthesisModule <- R6::R6Class(
              "stdDiffAfter",
              "stdDiffVarAfter")
   } else {
-	
-	filtBefore <- (!is.na(group$stdDiffVarBefore) & group$stdDiffVarBefore != 0)
+
     groupBefore <- group |>
-      filter(filtBefore)
+      filter(!is.na(.data$stdDiffVarBefore) & .data$stdDiffVarBefore != 0)
     if (nrow(groupBefore) == 0) {
-      group[filtBefore, "stdDiffBefore"] <- NA
-      group[filtBefore, "stdDiffVarBefore"] <- NA
+      stdDiffBefore <- NA
+      stdDiffVarBefore <- NA
     } else if (nrow(groupBefore) == 1) {
-      group[filtBefore, "stdDiffBefore"] <- groupBefore$stdDiffBefore
-      group[filtBefore, "stdDiffVarBefore"] <- groupBefore$stdDiffVarBefore
+      stdDiffBefore <- groupBefore$stdDiffBefore
+      stdDiffVarBefore <- groupBefore$stdDiffVarBefore
     } else {
-	  metaBefore <- metafor::rma(yi = groupBefore$stdDiffBefore,
-							 vi = groupBefore$stdDiffVarBefore,
-							 control = list(iter.max = 1000))
-	  group[filtBefore, "stdDiffBefore"] <- metaBefore$beta
-	  group[filtBefore, "stdDiffVarBefore"] <- metaBefore$se ^ 2
-	  group[!filtBefore, c("stdDiffBefore", "stdDiffVarBefore")] <- c(NA, NA)
+      metaBefore <- metafor::rma(yi = groupBefore$stdDiffBefore,
+                                 vi = groupBefore$stdDiffVarBefore,
+                                 control = list(iter.max = 1000))
+      stdDiffBefore <- metaBefore$beta
+      stdDiffVarBefore <- metaBefore$se ^ 2
     }
-	
-	filtAfter <- (!is.na(group$stdDiffVarAfter) & group$stdDiffVarAfter != 0)
+
     groupAfter <- group |>
-      filter(filtAfter)
+      filter(!is.na(.data$stdDiffVarAfter) & .data$stdDiffVarAfter != 0)
     if (nrow(groupAfter) == 0) {
-      group[filtAfter, "stdDiffAfter"] <- NA
-      group[filtAfter, "stdDiffVarAfter"] <- NA
+      stdDiffAfter <- NA
+      stdDiffVarAfter <- NA
     } else if (nrow(groupAfter) == 1) {
-      group[filtAfter, "stdDiffAfter"] <- groupAfter$stdDiffAfter
-      group[filtAfter, "stdDiffVarAfter"] <- groupAfter$stdDiffVarAfter
+      stdDiffAfter <- groupAfter$stdDiffAfter
+      stdDiffVarAfter <- groupAfter$stdDiffVarAfter
     } else {
       metaAfter <- metafor::rma(yi = groupAfter$stdDiffAfter,
                                  vi = groupAfter$stdDiffVarAfter,
                                  control = list(iter.max = 1000))
-      group[filtAfter, "stdDiffAfter"] <- metaAfter$beta
-      group[filtAfter, "stdDiffVarAfter"] <- metaAfter$se ^ 2
-	  group[!filtAfter, c("stdDiffAfter", "stdDiffVarAfter")] <- c(NA, NA)
+      stdDiffAfter <- metaAfter$beta
+      stdDiffVarAfter <- metaAfter$se ^ 2
     }
-	row <- tibble(
-	  targetComparatorId = group$targetComparatorId[1],
-	  analysisId = group$analysisId[1],
-	  covariateId = group$covariateId[1],
-	  stdDiffBefore = group$stdDiffBefore,
-	  stdDiffVarBefore = group$stdDiffVarBefore,
-	  stdDiffAfter = group$stdDiffAfter,
-	  stdDiffVarAfter = group$stdDiffVarAfter
-	)
+    row <- tibble(
+      targetComparatorId = group$targetComparatorId[1],
+      analysisId = group$analysisId[1],
+      covariateId = group$covariateId[1],
+      stdDiffBefore = stdDiffBefore,
+      stdDiffVarBefore = stdDiffVarBefore,
+      stdDiffAfter = stdDiffAfter,
+      stdDiffVarAfter = stdDiffVarAfter
+    )
   }
   if (!shared) {
     row$outcomeId <- group$outcomeId[1]
   }
   return(row)
-}
-
-.computeBalanceP <- function(sdm, sdmVariance, threshold) {
-  zUpper <- (abs(sdm) - threshold) / sqrt(sdmVariance)
-  pUpper <- pnorm(zUpper, lower.tail = FALSE)
-  zLower <- (-abs(sdm) - threshold) / sqrt(sdmVariance)
-  pLower <- pnorm(zLower, lower.tail = TRUE)
-  p <- pUpper + pLower
-  return(p)
 }
 
 .minOrNa <- function(x) {

--- a/R/Module-EvidenceSynthesis.R
+++ b/R/Module-EvidenceSynthesis.R
@@ -1275,7 +1275,7 @@ EvidenceSynthesisModule <- R6::R6Class(
     if (nrow(groupBefore) == 0) {
       group[filtBefore, "stdDiffBefore"] <- NA
       group[filtBefore, "stdDiffVarBefore"] <- NA
-    } else if (nrow(groupBefore == 1)) {
+    } else if (nrow(groupBefore) == 1) {
       group[filtBefore, "stdDiffBefore"] <- groupBefore$stdDiffBefore
       group[filtBefore, "stdDiffVarBefore"] <- groupBefore$stdDiffVarBefore
     } else {
@@ -1284,6 +1284,7 @@ EvidenceSynthesisModule <- R6::R6Class(
 							 control = list(iter.max = 1000))
 	  group[filtBefore, "stdDiffBefore"] <- metaBefore$beta
 	  group[filtBefore, "stdDiffVarBefore"] <- metaBefore$se ^ 2
+	  group[!filtBefore, c("stdDiffBefore", "stdDiffVarBefore")] <- c(NA, NA)
     }
 	
 	filtAfter <- (!is.na(group$stdDiffVarAfter) & group$stdDiffVarAfter != 0)
@@ -1292,7 +1293,7 @@ EvidenceSynthesisModule <- R6::R6Class(
     if (nrow(groupAfter) == 0) {
       group[filtAfter, "stdDiffAfter"] <- NA
       group[filtAfter, "stdDiffVarAfter"] <- NA
-    } else if (nrow(groupAfter == 1)) {
+    } else if (nrow(groupAfter) == 1) {
       group[filtAfter, "stdDiffAfter"] <- groupAfter$stdDiffAfter
       group[filtAfter, "stdDiffVarAfter"] <- groupAfter$stdDiffVarAfter
     } else {
@@ -1301,8 +1302,8 @@ EvidenceSynthesisModule <- R6::R6Class(
                                  control = list(iter.max = 1000))
       group[filtAfter, "stdDiffAfter"] <- metaAfter$beta
       group[filtAfter, "stdDiffVarAfter"] <- metaAfter$se ^ 2
+	  group[!filtAfter, c("stdDiffAfter", "stdDiffVarAfter")] <- c(NA, NA)
     }
-	
 	row <- tibble(
 	  targetComparatorId = group$targetComparatorId[1],
 	  analysisId = group$analysisId[1],

--- a/R/Module-EvidenceSynthesis.R
+++ b/R/Module-EvidenceSynthesis.R
@@ -1304,10 +1304,10 @@ EvidenceSynthesisModule <- R6::R6Class(
       targetComparatorId = group$targetComparatorId[1],
       analysisId = group$analysisId[1],
       covariateId = group$covariateId[1],
-      stdDiffBefore = stdDiffBefore[1],
-      stdDiffVarBefore = stdDiffVarBefore[1],
-      stdDiffAfter = stdDiffAfter[1],
-      stdDiffVarAfter = stdDiffVarAfter[1]
+      stdDiffBefore = stdDiffBefore,
+      stdDiffVarBefore = stdDiffVarBefore,
+      stdDiffAfter = stdDiffAfter,
+      stdDiffVarAfter = stdDiffVarAfter
     )
   }
   if (!shared) {

--- a/R/Module-EvidenceSynthesis.R
+++ b/R/Module-EvidenceSynthesis.R
@@ -1281,7 +1281,7 @@ EvidenceSynthesisModule <- R6::R6Class(
       metaBefore <- metafor::rma(yi = groupBefore$stdDiffBefore,
                                  vi = groupBefore$stdDiffVarBefore,
                                  control = list(iter.max = 1000))
-      stdDiffBefore <- metaBefore$beta
+      stdDiffBefore <- metaBefore$beta[1, 1]
       stdDiffVarBefore <- metaBefore$se ^ 2
     }
 
@@ -1297,7 +1297,7 @@ EvidenceSynthesisModule <- R6::R6Class(
       metaAfter <- metafor::rma(yi = groupAfter$stdDiffAfter,
                                  vi = groupAfter$stdDiffVarAfter,
                                  control = list(iter.max = 1000))
-      stdDiffAfter <- metaAfter$beta
+      stdDiffAfter <- metaAfter$beta[1, 1]
       stdDiffVarAfter <- metaAfter$se ^ 2
     }
     row <- tibble(

--- a/R/Module-EvidenceSynthesis.R
+++ b/R/Module-EvidenceSynthesis.R
@@ -1304,10 +1304,10 @@ EvidenceSynthesisModule <- R6::R6Class(
       targetComparatorId = group$targetComparatorId[1],
       analysisId = group$analysisId[1],
       covariateId = group$covariateId[1],
-      stdDiffBefore = stdDiffBefore,
-      stdDiffVarBefore = stdDiffVarBefore,
-      stdDiffAfter = stdDiffAfter,
-      stdDiffVarAfter = stdDiffVarAfter
+      stdDiffBefore = stdDiffBefore[1],
+      stdDiffVarBefore = stdDiffVarBefore[1],
+      stdDiffAfter = stdDiffAfter[1],
+      stdDiffVarAfter = stdDiffVarAfter[1]
     )
   }
   if (!shared) {

--- a/R/Module-EvidenceSynthesis.R
+++ b/R/Module-EvidenceSynthesis.R
@@ -1268,47 +1268,50 @@ EvidenceSynthesisModule <- R6::R6Class(
              "stdDiffAfter",
              "stdDiffVarAfter")
   } else {
-
+	
+	filtBefore <- (!is.na(group$stdDiffVarBefore) & group$stdDiffVarBefore != 0)
     groupBefore <- group |>
-      filter(!is.na(.data$stdDiffVarBefore) & .data$stdDiffVarBefore != 0)
+      filter(filtBefore)
     if (nrow(groupBefore) == 0) {
-      stdDiffBefore <- NA
-      stdDiffVarBefore <- NA
+      group[filtBefore, "stdDiffBefore"] <- NA
+      group[filtBefore, "stdDiffVarBefore"] <- NA
     } else if (nrow(groupBefore == 1)) {
-      stdDiffBefore <- groupBefore$stdDiffBefore
-      stdDiffVarBefore <- groupBefore$stdDiffVarBefore
+      group[filtBefore, "stdDiffBefore"] <- groupBefore$stdDiffBefore
+      group[filtBefore, "stdDiffVarBefore"] <- groupBefore$stdDiffVarBefore
     } else {
-      metaBefore <- metafor::rma(yi = groupBefore$stdDiffBefore,
-                                 vi = groupBefore$stdDiffVarBefore,
-                                 control = list(iter.max = 1000))
-      stdDiffBefore <- metaBefore$beta
-      stdDiffVarBefore <- metaBefore$se ^ 2
+	  metaBefore <- metafor::rma(yi = groupBefore$stdDiffBefore,
+							 vi = groupBefore$stdDiffVarBefore,
+							 control = list(iter.max = 1000))
+	  group[filtBefore, "stdDiffBefore"] <- metaBefore$beta
+	  group[filtBefore, "stdDiffVarBefore"] <- metaBefore$se ^ 2
     }
-
+	
+	filtAfter <- (!is.na(group$stdDiffVarAfter) & group$stdDiffVarAfter != 0)
     groupAfter <- group |>
-      filter(!is.na(.data$stdDiffVarAfter) & .data$stdDiffVarAfter != 0)
+      filter(filtAfter)
     if (nrow(groupAfter) == 0) {
-      stdDiffAfter <- NA
-      stdDiffVarAfter <- NA
+      group[filtAfter, "stdDiffAfter"] <- NA
+      group[filtAfter, "stdDiffVarAfter"] <- NA
     } else if (nrow(groupAfter == 1)) {
-      stdDiffAfter <- groupAfter$stdDiffAfter
-      stdDiffVarAfter <- groupAfter$stdDiffVarAfter
+      group[filtAfter, "stdDiffAfter"] <- groupAfter$stdDiffAfter
+      group[filtAfter, "stdDiffVarAfter"] <- groupAfter$stdDiffVarAfter
     } else {
       metaAfter <- metafor::rma(yi = groupAfter$stdDiffAfter,
                                  vi = groupAfter$stdDiffVarAfter,
                                  control = list(iter.max = 1000))
-      stdDiffAfter <- metaAfter$beta
-      stdDiffVarAfter <- metaAfter$se ^ 2
+      group[filtAfter, "stdDiffAfter"] <- metaAfter$beta
+      group[filtAfter, "stdDiffVarAfter"] <- metaAfter$se ^ 2
     }
-    row <- tibble(
-      targetComparatorId = group$targetComparatorId[1],
-      analysisId = group$analysisId[1],
-      covariateId = group$covariateId[1],
-      stdDiffBefore = stdDiffBefore[1],
-      stdDiffVarBefore = stdDiffVarBefore[1],
-      stdDiffAfter = stdDiffAfter[1],
-      stdDiffVarAfter = stdDiffVarAfter[1]
-    )
+	
+	row <- tibble(
+	  targetComparatorId = group$targetComparatorId[1],
+	  analysisId = group$analysisId[1],
+	  covariateId = group$covariateId[1],
+	  stdDiffBefore = group$stdDiffBefore,
+	  stdDiffVarBefore = group$stdDiffVarBefore,
+	  stdDiffAfter = group$stdDiffAfter,
+	  stdDiffVarAfter = group$stdDiffVarAfter
+	)
   }
   if (!shared) {
     row$outcomeId <- group$outcomeId[1]


### PR DESCRIPTION
This is a brief change related to how EvidenceSynthesis collapses statistics across groups in the function `.metaAnalyzeSingleCovariate`. Prior to this fix, for a minority of groups within the batches, tibble would error out, complaining that `stdDiffAfter` was not the expected length:

```log
Error in 'tibble'
! Tibble columns must have compatible sizes
* Size 3: Existing data.
* Size 2: Column 'stdDiffAfter'
i Only values of size 1 are recycled
```

This comes from the fact that we're filtering the before and after statistics separately. If one of the filters results in 2 rows, and the other 3 rows, you cannot make a single tibble out of the combination because of length differences. I've switched to a masking paradigm, where only unmasked rows participate in the rma process, but masked rows are returned as NA values for the before or after pairs.

Note also that it may be useful to add warnings/verbose logging in the event that results from CM do not contain rows where unblind_for_evidence_synthesis == 1. Currently this gives a cryptic log referring to .data but with no stack trace or other information available.




